### PR TITLE
doc: compile instructions for Debian/Ubuntu added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Rust wrapper for FFmpeg libraries
+
+## Compile instructions
+
+### Debian (or perhaps Ubuntu)
+
+```bash
+apt install libavformat-dev libavcodec-dev libswscale-dev
+
+FFMPEG_INCLUDE_DIR=/usr/include/ cargo build
+```


### PR DESCRIPTION
Added instructions how to compile the create on Debian/Ubuntu without compiling ffmpeg manually.

Perhaps https://github.com/angelcam/streaming-server/blob/master/Dockerfile#L12 could be updated as well unless you need to compile ffmpeg with specific args...