### PR TITLE
Fix minimum required pkg-config version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libc        = "0.2"
 
 [build-dependencies]
 cc         = "1.0"
-pkg-config = "0.3"
+pkg-config = "0.3.16"
 
 [dev-dependencies]
 clap = "2.33"


### PR DESCRIPTION
The print_system_cflags method isn't available until 0.3.16.