### PR TITLE
Expose thread_count so it can be set & read from client code.

### DIFF
--- a/src/codec/audio/mod.rs
+++ b/src/codec/audio/mod.rs
@@ -115,6 +115,14 @@ impl AudioDecoderBuilder {
         self
     }
 
+    /// Sets the maximum number of threads for the decoder to use.
+    /// Setting the thread count to 0 will adjust the number of threads to be optimal for the CPU running the program.
+    /// This value defaults to 1 in some versions of FFMPEG.
+    pub fn thread_count(self, thread_count: i32) -> Self {
+        unsafe { super::ffw_decoder_set_thread_count(self.ptr, thread_count) }
+        self
+    }
+
     /// Build the decoder.
     pub fn build(mut self) -> Result<AudioDecoder, Error> {
         unsafe {
@@ -167,6 +175,18 @@ impl AudioDecoder {
     /// Get decoder builder for a given codec.
     pub fn builder(codec: &str) -> Result<AudioDecoderBuilder, Error> {
         AudioDecoderBuilder::new(codec)
+    }
+
+    /// Sets the maximum number of threads for the decoder to use.
+    /// Setting the thread count to 0 will adjust the number of threads to be optimal for the CPU running the program.
+    /// This value defaults to 1 in some versions of FFMPEG.
+    pub fn set_thread_count(&self, thread_count: i32) {
+        unsafe { super::ffw_decoder_set_thread_count(self.ptr, thread_count) }
+    }
+
+    /// Gets the maximum number of threads the decoder will use.
+    pub fn get_thread_count(&self) -> i32 {
+        unsafe { super::ffw_decoder_get_thread_count(self.ptr) }
     }
 }
 

--- a/src/codec/mod.c
+++ b/src/codec/mod.c
@@ -184,6 +184,8 @@ typedef struct Decoder {
 
 Decoder* ffw_decoder_new(const char* codec);
 Decoder* ffw_decoder_from_codec_parameters(const AVCodecParameters* params);
+void ffw_decoder_set_thread_count(Decoder* decoder, int threadCount);
+int ffw_decoder_get_thread_count(Decoder* decoder);
 int ffw_decoder_set_extradata(Decoder* decoder, const uint8_t* extradata, int size);
 int ffw_decoder_set_initial_option(Decoder* decoder, const char* key, const char* value);
 int ffw_decoder_open(Decoder* decoder);
@@ -262,6 +264,14 @@ err:
     ffw_decoder_free(res);
 
     return NULL;
+}
+
+void ffw_decoder_set_thread_count(Decoder* decoder, int threadCount) {
+    decoder->cc->thread_count = threadCount;
+}
+
+int ffw_decoder_get_thread_count(Decoder* decoder) {
+    return decoder->cc->thread_count;
 }
 
 int ffw_decoder_set_extradata(Decoder* decoder, const uint8_t* extradata, int size) {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -52,6 +52,8 @@ extern "C" {
 
     fn ffw_decoder_new(codec: *const c_char) -> *mut c_void;
     fn ffw_decoder_from_codec_parameters(params: *const c_void) -> *mut c_void;
+    fn ffw_decoder_set_thread_count(decoder: *mut c_void, thread_count: c_int);
+    fn ffw_decoder_get_thread_count(decoder: *mut c_void) -> c_int;
     fn ffw_decoder_set_extradata(decoder: *mut c_void, extradata: *const u8, size: c_int) -> c_int;
     fn ffw_decoder_set_initial_option(
         decoder: *mut c_void,

--- a/src/codec/video/mod.rs
+++ b/src/codec/video/mod.rs
@@ -113,6 +113,14 @@ impl VideoDecoderBuilder {
         self
     }
 
+    /// Sets the maximum number of threads for the decoder to use.
+    /// Setting the thread count to 0 will adjust the number of threads to be optimal for the CPU running the program.
+    /// This value defaults to 1 in some versions of FFMPEG.
+    pub fn thread_count(self, thread_count: i32) -> Self {
+        unsafe { super::ffw_decoder_set_thread_count(self.ptr, thread_count) }
+        self
+    }
+
     /// Build the decoder.
     pub fn build(mut self) -> Result<VideoDecoder, Error> {
         unsafe {
@@ -165,6 +173,18 @@ impl VideoDecoder {
     /// Get decoder builder for a given codec.
     pub fn builder(codec: &str) -> Result<VideoDecoderBuilder, Error> {
         VideoDecoderBuilder::new(codec)
+    }
+
+    /// Sets the maximum number of threads for the decoder to use.
+    /// Setting the thread count to 0 will adjust the number of threads to be optimal for the CPU running the program.
+    /// This value defaults to 1 in some versions of FFMPEG.
+    pub fn set_thread_count(&self, thread_count: i32) {
+        unsafe { super::ffw_decoder_set_thread_count(self.ptr, thread_count) }
+    }
+
+    /// Gets the maximum number of threads the decoder will use.
+    pub fn get_thread_count(&self) -> i32 {
+        unsafe { super::ffw_decoder_get_thread_count(self.ptr) }
     }
 }
 


### PR DESCRIPTION
I noticed I was getting really bad performance decoding h264 video. It turned out that the version of FFMPEG I was using automatically dedicates only 1 thread to do decoding work. This pull request exposes the thread_count field so that it can be set by client code.

The alternative solution to this situation would be to initialise thread_count to 0 when creating the AVCodecContext. However, that might have power saving implications for some applications. I figured in this case it might be best to let the client code decide?

Let me know your thoughts.