### PR TITLE
Add codec parameters type for subtitles.

### DIFF
--- a/src/codec/mod.c
+++ b/src/codec/mod.c
@@ -47,6 +47,10 @@ AVCodecParameters* ffw_video_codec_parameters_new(const char* codec_name) {
     return ffw_codec_parameters_new(codec_name, AVMEDIA_TYPE_VIDEO);
 }
 
+AVCodecParameters* ffw_subtitle_codec_parameters_new(const char* codec_name) {
+    return ffw_codec_parameters_new(codec_name, AVMEDIA_TYPE_SUBTITLE);
+}
+
 AVCodecParameters* ffw_codec_parameters_clone(const AVCodecParameters* src) {
     AVCodecParameters* res = avcodec_parameters_alloc();
     if (res == NULL) {
@@ -71,6 +75,10 @@ int ffw_codec_parameters_is_audio_codec(const AVCodecParameters* params) {
 
 int ffw_codec_parameters_is_video_codec(const AVCodecParameters* params) {
     return params->codec_type == AVMEDIA_TYPE_VIDEO;
+}
+
+int ffw_codec_parameters_is_subtitle_codec(const AVCodecParameters* params) {
+    return params->codec_type == AVMEDIA_TYPE_SUBTITLE;
 }
 
 const char* ffw_codec_parameters_get_decoder_name(const AVCodecParameters* params) {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -809,20 +809,6 @@ impl SubtitleCodecParameters {
     pub fn encoder_name(&self) -> Option<&'static str> {
         self.inner.encoder_name()
     }
-
-    /// Get extradata.
-    pub fn extradata(&self) -> Option<&[u8]> {
-        unsafe {
-            let data = ffw_codec_parameters_get_extradata(self.inner.ptr) as *const u8;
-            let size = ffw_codec_parameters_get_extradata_size(self.inner.ptr) as usize;
-
-            if data.is_null() {
-                None
-            } else {
-                Some(slice::from_raw_parts(data, size))
-            }
-        }
-    }
 }
 
 impl AsRef<InnerCodecParameters> for SubtitleCodecParameters {


### PR DESCRIPTION
Mainly this is to allow remuxing subtitles (as right now there's no way to specify a subtitle codec for a stream), i.e. take a .mkv with srt subtitle track and split it into a separate webvtt file.

I did not add a builder for subtitle params as it seemed excessive given that there's only one parameter - codec name.