### PR TITLE
Allow to pass format context URL to muxer builder.

### DIFF
--- a/src/format/muxer.c
+++ b/src/format/muxer.c
@@ -104,6 +104,12 @@ int ffw_muxer_set_option(Muxer* muxer, const char* key, const char* value) {
     return av_opt_set(muxer->fc, key, value, AV_OPT_SEARCH_CHILDREN);
 }
 
+int ffw_muxer_set_url(Muxer* muxer, const char* url) {
+    av_freep(&muxer->fc->url);
+    muxer->fc->url = av_strdup(url);
+    return muxer->fc->url ? 0 : AVERROR(ENOMEM);
+}
+
 static int ffw_rescale_packet_timestamps(Muxer* muxer, AVPacket* packet, uint32_t src_tb_num, uint32_t src_tb_den) {
     AVStream* stream;
     AVRational src_tb;

--- a/src/format/muxer.rs
+++ b/src/format/muxer.rs
@@ -90,6 +90,11 @@ impl MuxerBuilder {
         self
     }
 
+    /// Set the `url` field of FFmpeg format context to the specified value.
+    ///
+    /// __WARNING__: this is a hack to accomodate certain muxer types (e.g.
+    /// DASH) that bypass avio abstraction layer/produce multiple output files.
+    /// Setting this can cause FFmpeg open its own files or sockets.
     pub fn set_url(self, url: &str) -> MuxerBuilder {
         let url = CString::new(url).expect("invalid URL value");
         let ret = unsafe { ffw_muxer_set_url(self.ptr, url.as_ptr() as _) };

--- a/src/format/muxer.rs
+++ b/src/format/muxer.rs
@@ -23,6 +23,7 @@ extern "C" {
         value: *const c_char,
     ) -> c_int;
     fn ffw_muxer_set_option(muxer: *mut c_void, key: *const c_char, value: *const c_char) -> c_int;
+    fn ffw_muxer_set_url(muxer: *mut c_void, url: *const c_char) -> c_int;
     fn ffw_muxer_write_frame(
         muxer: *mut c_void,
         packet: *mut c_void,
@@ -86,6 +87,15 @@ impl MuxerBuilder {
             panic!("unable to allocate an option");
         }
 
+        self
+    }
+
+    pub fn set_url(self, url: &str) -> MuxerBuilder {
+        let url = CString::new(url).expect("invalid URL value");
+        let ret = unsafe { ffw_muxer_set_url(self.ptr, url.as_ptr() as _) };
+        if ret < 0 {
+            panic!("unable to allocate memory for URL")
+        }
         self
     }
 


### PR DESCRIPTION
Certain muxers (e.g. dash) use this context field to determine the base directory for output files, as they cannot get it from avio.