### PR TITLE
Allow setting stream metadata from safe rust

### DIFF
--- a/src/format/muxer.c
+++ b/src/format/muxer.c
@@ -21,8 +21,7 @@ typedef struct Muxer {
 Muxer* ffw_muxer_new();
 unsigned ffw_muxer_get_nb_streams(const Muxer*);
 int ffw_muxer_new_stream(Muxer*, const AVCodecParameters*);
-int ffw_muxer_set_int_option(Muxer* const, int, const char*, int);
-int ffw_muxer_set_string_option(Muxer* const, int, const char*, const char*);
+int ffw_muxer_set_stream_option(Muxer* const, int, const char*, const char*);
 int ffw_muxer_init(Muxer*, AVIOContext*, AVOutputFormat*);
 int ffw_muxer_get_option(Muxer*, const char*, uint8_t**);
 int ffw_muxer_set_initial_option(Muxer*, const char*, const char*);
@@ -77,12 +76,7 @@ int ffw_muxer_new_stream(Muxer* muxer, const AVCodecParameters* params) {
     return s->index;
 }
 
-int ffw_muxer_set_int_option(Muxer* const muxer, int stream_index, const char* key, int value) {
-    AVStream* stream = muxer->fc->streams[stream_index];
-    return av_dict_set_int(&stream->metadata, key, value, 0);
-}
-
-int ffw_muxer_set_string_option(Muxer* const muxer, int stream_index, const char* key, const char* value) {
+int ffw_muxer_set_stream_option(Muxer* const muxer, int stream_index, const char* key, const char* value) {
     AVStream* stream = muxer->fc->streams[stream_index];
     return av_dict_set(&stream->metadata, key, value, 0);
 }

--- a/src/format/muxer.c
+++ b/src/format/muxer.c
@@ -21,6 +21,8 @@ typedef struct Muxer {
 Muxer* ffw_muxer_new();
 unsigned ffw_muxer_get_nb_streams(const Muxer*);
 int ffw_muxer_new_stream(Muxer*, const AVCodecParameters*);
+int ffw_muxer_set_int_option(Muxer* const, int, const char*, int);
+int ffw_muxer_set_string_option(Muxer* const, int, const char*, const char*);
 int ffw_muxer_init(Muxer*, AVIOContext*, AVOutputFormat*);
 int ffw_muxer_get_option(Muxer*, const char*, uint8_t**);
 int ffw_muxer_set_initial_option(Muxer*, const char*, const char*);
@@ -73,6 +75,16 @@ int ffw_muxer_new_stream(Muxer* muxer, const AVCodecParameters* params) {
     s->codecpar->codec_tag = 0;
 
     return s->index;
+}
+
+int ffw_muxer_set_int_option(Muxer* const muxer, int stream_index, const char* key, int value) {
+    AVStream* stream = muxer->fc->streams[stream_index];
+    return av_dict_set_int(&stream->metadata, key, value, 0);
+}
+
+int ffw_muxer_set_string_option(Muxer* const muxer, int stream_index, const char* key, const char* value) {
+    AVStream* stream = muxer->fc->streams[stream_index];
+    return av_dict_set(&stream->metadata, key, value, 0);
 }
 
 int ffw_muxer_init(

--- a/src/format/muxer.rs
+++ b/src/format/muxer.rs
@@ -93,8 +93,11 @@ impl MuxerBuilder {
 
         let key = CString::new(name).expect("invalid option name");
         let value = CString::new(value.to_string()).expect("invalid option value");
-        unsafe {
-            ffw_muxer_set_stream_option(self.ptr, stream_index, key.as_ptr(), value.as_ptr());
+        let ret = unsafe {
+            ffw_muxer_set_stream_option(self.ptr, stream_index, key.as_ptr(), value.as_ptr())
+        };
+        if ret < 0 {
+            panic!("unable to allocate an option");
         }
         self
     }

--- a/src/format/muxer.rs
+++ b/src/format/muxer.rs
@@ -19,6 +19,8 @@ extern "C" {
     fn ffw_muxer_new() -> *mut c_void;
     fn ffw_muxer_get_nb_streams(muxer: *const c_void) -> c_uint;
     fn ffw_muxer_new_stream(muxer: *mut c_void, params: *const c_void) -> c_int;
+    fn ffw_muxer_set_int_option(muxer: *mut c_void, stream_index: i32, key: *const c_char, value: i32) -> c_int;
+    fn ffw_muxer_set_string_option(muxer: *mut c_void, stream_index: i32, key: *const c_char, value: *const c_char) -> c_int;
     fn ffw_muxer_init(muxer: *mut c_void, io_context: *mut c_void, format: *mut c_void) -> c_int;
     fn ffw_muxer_set_initial_option(
         muxer: *mut c_void,
@@ -48,6 +50,11 @@ pub struct MuxerBuilder {
     interleaved: bool,
 }
 
+pub enum DictOption {
+    IntOption { key: String, value: i32 },
+    StringOption { key: String, value: String }
+}
+
 impl MuxerBuilder {
     /// Create a new muxer builder.
     fn new() -> MuxerBuilder {
@@ -63,12 +70,31 @@ impl MuxerBuilder {
         }
     }
 
-    /// Add a new stream with given parameters.
-    pub fn add_stream(&mut self, params: &CodecParameters) -> Result<(), Error> {
-        let ret = unsafe { ffw_muxer_new_stream(self.ptr, params.as_ptr()) };
+    /// Add a new stream with given parameters. The metadata options will be set on the new stream's options dict.
+    pub fn add_stream(&mut self, params: &CodecParameters, metadata: Option<Vec<DictOption>>) -> Result<(), Error> {
+        let stream_index = unsafe { ffw_muxer_new_stream(self.ptr, params.as_ptr()) };
 
-        if ret < 0 {
-            return Err(Error::from_raw_error_code(ret));
+        if stream_index < 0 {
+            return Err(Error::from_raw_error_code(stream_index));
+        }
+
+        if let Some(options) = metadata {
+            for option in options {
+                let ret: i32 = match option {
+                    DictOption::IntOption { key, value } => unsafe {
+                        let key = CString::new(key).expect("invalid option name");
+                        ffw_muxer_set_int_option(self.ptr, stream_index, key.as_ptr(), value)
+                    },
+                    DictOption::StringOption { key, value } => unsafe {
+                        let key = CString::new(key).expect("invalid option name");
+                        let value = CString::new(value).expect("invalid option value");
+                        ffw_muxer_set_string_option(self.ptr, stream_index, key.as_ptr(), value.as_ptr())
+                    },
+                };
+                if ret < 0 {
+                    return Err(Error::from_raw_error_code(ret));
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
This patch allows specifying metadata options to be applied to an `AVStream` after it's created.

#19 