### PR TITLE
Expose frame rate of streams

### DIFF
--- a/src/codec/audio/transcoder.rs
+++ b/src/codec/audio/transcoder.rs
@@ -4,6 +4,7 @@
 //! audio decoder/resampler/encoder into a single pipeline.
 
 use std::collections::VecDeque;
+use std::convert::TryInto;
 
 use crate::Error;
 
@@ -67,12 +68,24 @@ impl AudioTranscoderBuilder {
     pub fn build(self) -> Result<AudioTranscoder, Error> {
         let decoder = self
             .decoder_builder
-            .time_base(TimeBase::new(1, self.input.sample_rate()))
+            .time_base(TimeBase::new(
+                1,
+                self.input
+                    .sample_rate()
+                    .try_into()
+                    .map_err(|e| Error::new(e))?,
+            ))
             .build()?;
 
         let encoder = self
             .encoder_builder
-            .time_base(TimeBase::new(1, self.output.sample_rate()))
+            .time_base(TimeBase::new(
+                1,
+                self.output
+                    .sample_rate()
+                    .try_into()
+                    .map_err(|e| Error::new(e))?,
+            ))
             .build()?;
 
         let resampler = AudioResampler::builder()

--- a/src/codec/bsf.c
+++ b/src/codec/bsf.c
@@ -38,7 +38,7 @@ int ffw_bsf_set_output_codec_parameters(AVBSFContext* context, const AVCodecPara
     return avcodec_parameters_copy(context->par_out, params);
 }
 
-int ffw_bsf_init(AVBSFContext* context, uint32_t itb_num, uint32_t itb_den, uint32_t otb_num, uint32_t otb_den) {
+int ffw_bsf_init(AVBSFContext* context, int itb_num, int itb_den, int otb_num, int otb_den) {
     context->time_base_in.num = itb_num;
     context->time_base_in.den = itb_den;
     context->time_base_out.num = otb_num;

--- a/src/codec/bsf.rs
+++ b/src/codec/bsf.rs
@@ -14,10 +14,10 @@ extern "C" {
     fn ffw_bsf_set_output_codec_parameters(context: *mut c_void, params: *const c_void) -> c_int;
     fn ffw_bsf_init(
         context: *mut c_void,
-        itb_num: u32,
-        itb_den: u32,
-        otb_num: u32,
-        otb_den: u32,
+        itb_num: c_int,
+        itb_den: c_int,
+        otb_num: c_int,
+        otb_den: c_int,
     ) -> c_int;
     fn ffw_bsf_push(context: *mut c_void, packet: *mut c_void) -> c_int;
     fn ffw_bsf_flush(context: *mut c_void) -> c_int;

--- a/src/format/demuxer.c
+++ b/src/format/demuxer.c
@@ -57,7 +57,7 @@ int ffw_demuxer_set_option(Demuxer* demuxer, const char* key, const char* value)
 int ffw_demuxer_find_stream_info(Demuxer* demuxer, int64_t max_analyze_duration);
 unsigned ffw_demuxer_get_nb_streams(const Demuxer* demuxer);
 AVStream* ffw_demuxer_get_stream(Demuxer* demuxer, unsigned stream_index);
-int ffw_demuxer_read_frame(Demuxer* demuxer, AVPacket** packet, uint32_t* tb_num, uint32_t* tb_den);
+int ffw_demuxer_read_frame(Demuxer* demuxer, AVPacket** packet, int* tb_num, int* tb_den);
 int ffw_demuxer_seek(Demuxer* demuxer, int64_t timestamp, int seek_by, int seek_target);
 void ffw_demuxer_free(Demuxer* demuxer);
 
@@ -133,7 +133,7 @@ AVStream* ffw_demuxer_get_stream(Demuxer* demuxer, unsigned stream_index) {
     return demuxer->fc->streams[stream_index];
 }
 
-int ffw_demuxer_read_frame(Demuxer* demuxer, AVPacket** packet, uint32_t* tb_num, uint32_t* tb_den) {
+int ffw_demuxer_read_frame(Demuxer* demuxer, AVPacket** packet, int* tb_num, int* tb_den) {
     AVStream* stream;
     AVPacket* res;
     int ret;

--- a/src/format/demuxer.rs
+++ b/src/format/demuxer.rs
@@ -47,8 +47,8 @@ extern "C" {
     fn ffw_demuxer_read_frame(
         demuxer: *mut c_void,
         packet: *mut *mut c_void,
-        tb_num: *mut u32,
-        tb_den: *mut u32,
+        tb_num: *mut c_int,
+        tb_den: *mut c_int,
     ) -> c_int;
     fn ffw_demuxer_seek(
         demuxer: *mut c_void,

--- a/src/format/muxer.c
+++ b/src/format/muxer.c
@@ -27,8 +27,8 @@ int ffw_muxer_get_option(Muxer*, const char*, uint8_t**);
 int ffw_muxer_set_initial_option(Muxer*, const char*, const char*);
 int ffw_muxer_set_option(Muxer*, const char*, const char*);
 int ffw_muxer_set_metadata(Muxer*, const char*, const char*);
-int ffw_muxer_write_frame(Muxer*, AVPacket*, uint32_t, uint32_t);
-int ffw_muxer_interleaved_write_frame(Muxer*, AVPacket*, uint32_t, uint32_t);
+int ffw_muxer_write_frame(Muxer*, AVPacket*, int, int);
+int ffw_muxer_interleaved_write_frame(Muxer*, AVPacket*, int, int);
 int ffw_muxer_free(Muxer*);
 
 Muxer* ffw_muxer_new() {
@@ -120,7 +120,7 @@ int ffw_muxer_set_metadata(Muxer* muxer, const char* key, const char* value) {
     return av_dict_set(&muxer->fc->metadata, key, value, 0);
 }
 
-static int ffw_rescale_packet_timestamps(Muxer* muxer, AVPacket* packet, uint32_t src_tb_num, uint32_t src_tb_den) {
+static int ffw_rescale_packet_timestamps(Muxer* muxer, AVPacket* packet, int src_tb_num, int src_tb_den) {
     AVStream* stream;
     AVRational src_tb;
 
@@ -146,7 +146,7 @@ static int ffw_rescale_packet_timestamps(Muxer* muxer, AVPacket* packet, uint32_
     return 0;
 }
 
-int ffw_muxer_write_frame(Muxer* muxer, AVPacket* packet, uint32_t tb_num, uint32_t tb_den) {
+int ffw_muxer_write_frame(Muxer* muxer, AVPacket* packet, int tb_num, int tb_den) {
     int ret = ffw_rescale_packet_timestamps(muxer, packet, tb_num, tb_den);
 
     if (ret < 0) {
@@ -156,7 +156,7 @@ int ffw_muxer_write_frame(Muxer* muxer, AVPacket* packet, uint32_t tb_num, uint3
     return av_write_frame(muxer->fc, packet);
 }
 
-int ffw_muxer_interleaved_write_frame(Muxer* muxer, AVPacket* packet, uint32_t tb_num, uint32_t tb_den) {
+int ffw_muxer_interleaved_write_frame(Muxer* muxer, AVPacket* packet, int tb_num, int tb_den) {
     int ret = ffw_rescale_packet_timestamps(muxer, packet, tb_num, tb_den);
 
     if (ret < 0) {

--- a/src/format/muxer.rs
+++ b/src/format/muxer.rs
@@ -41,14 +41,14 @@ extern "C" {
     fn ffw_muxer_write_frame(
         muxer: *mut c_void,
         packet: *mut c_void,
-        tb_num: u32,
-        tb_den: u32,
+        tb_num: c_int,
+        tb_den: c_int,
     ) -> c_int;
     fn ffw_muxer_interleaved_write_frame(
         muxer: *mut c_void,
         packet: *mut c_void,
-        tb_num: u32,
-        tb_den: u32,
+        tb_num: c_int,
+        tb_den: c_int,
     ) -> c_int;
     fn ffw_muxer_free(muxer: *mut c_void) -> c_int;
 }

--- a/src/format/stream.c
+++ b/src/format/stream.c
@@ -1,14 +1,13 @@
 #include <libavformat/avformat.h>
 
-void ffw_stream_get_time_base(const AVStream* stream, uint32_t* num, uint32_t* den);
-void ffw_stream_get_frame_rate(const AVStream* stream, uint32_t* num, uint32_t* den);
+void ffw_stream_get_time_base(const AVStream* stream, int* num, int* den);
 int64_t ffw_stream_get_start_time(const AVStream* stream);
 int64_t ffw_stream_get_duration(const AVStream* stream);
 int64_t ffw_stream_get_nb_frames(const AVStream* stream);
 AVCodecParameters* ffw_stream_get_codec_parameters(const AVStream* stream);
 int ffw_stream_set_metadata(AVStream* stream, const char* key, const char* value);
 
-void ffw_stream_get_time_base(const AVStream* stream, uint32_t* num, uint32_t* den) {
+void ffw_stream_get_time_base(const AVStream* stream, int* num, int* den) {
     *num = stream->time_base.num;
     *den = stream->time_base.den;
 }

--- a/src/format/stream.c
+++ b/src/format/stream.c
@@ -13,9 +13,14 @@ void ffw_stream_get_time_base(const AVStream* stream, uint32_t* num, uint32_t* d
     *den = stream->time_base.den;
 }
 
-void ffw_stream_get_frame_rate(const AVStream* stream, uint32_t* num, uint32_t* den) {
+void ffw_stream_get_r_frame_rate(const AVStream* stream, int* num, int* den) {
     *num = stream->r_frame_rate.num;
     *den = stream->r_frame_rate.den;
+}
+
+void ffw_stream_get_avg_frame_rate(const AVStream* stream, int* num, int* den) {
+    *num = stream->avg_frame_rate.num;
+    *den = stream->avg_frame_rate.den;
 }
 
 int64_t ffw_stream_get_start_time(const AVStream* stream) {

--- a/src/format/stream.c
+++ b/src/format/stream.c
@@ -1,6 +1,7 @@
 #include <libavformat/avformat.h>
 
 void ffw_stream_get_time_base(const AVStream* stream, uint32_t* num, uint32_t* den);
+void ffw_stream_get_frame_rate(const AVStream* stream, uint32_t* num, uint32_t* den);
 int64_t ffw_stream_get_start_time(const AVStream* stream);
 int64_t ffw_stream_get_duration(const AVStream* stream);
 int64_t ffw_stream_get_nb_frames(const AVStream* stream);
@@ -10,6 +11,11 @@ int ffw_stream_set_metadata(AVStream* stream, const char* key, const char* value
 void ffw_stream_get_time_base(const AVStream* stream, uint32_t* num, uint32_t* den) {
     *num = stream->time_base.num;
     *den = stream->time_base.den;
+}
+
+void ffw_stream_get_frame_rate(const AVStream* stream, uint32_t* num, uint32_t* den) {
+    *num = stream->r_frame_rate.num;
+    *den = stream->r_frame_rate.den;
 }
 
 int64_t ffw_stream_get_start_time(const AVStream* stream) {

--- a/src/format/stream.rs
+++ b/src/format/stream.rs
@@ -12,9 +12,9 @@ use crate::{
 };
 
 extern "C" {
-    fn ffw_stream_get_time_base(stream: *const c_void, num: *mut u32, den: *mut u32);
-    fn ffw_stream_get_r_frame_rate(stream: *const c_void, num: *mut i32, den: *mut i32);
-    fn ffw_stream_get_avg_frame_rate(stream: *const c_void, num: *mut i32, den: *mut i32);
+    fn ffw_stream_get_time_base(stream: *const c_void, num: *mut c_int, den: *mut c_int);
+    fn ffw_stream_get_r_frame_rate(stream: *const c_void, num: *mut c_int, den: *mut c_int);
+    fn ffw_stream_get_avg_frame_rate(stream: *const c_void, num: *mut c_int, den: *mut c_int);
     fn ffw_stream_get_start_time(stream: *const c_void) -> i64;
     fn ffw_stream_get_duration(stream: *const c_void) -> i64;
     fn ffw_stream_get_nb_frames(stream: *const c_void) -> i64;
@@ -35,8 +35,8 @@ pub struct Stream {
 impl Stream {
     /// Create a new stream from its raw representation.
     pub(crate) unsafe fn from_raw_ptr(ptr: *mut c_void) -> Self {
-        let mut num = 0_u32;
-        let mut den = 0_u32;
+        let mut num = 0;
+        let mut den = 0;
 
         ffw_stream_get_time_base(ptr, &mut num, &mut den);
 
@@ -53,8 +53,8 @@ impl Stream {
 
     /// Get real base framerate of the stream.
     pub fn r_frame_rate(&self) -> Rational {
-        let mut num = 0_i32;
-        let mut den = 0_i32;
+        let mut num = 0;
+        let mut den = 0;
 
         unsafe {
             ffw_stream_get_r_frame_rate(self.ptr, &mut num, &mut den);
@@ -65,8 +65,8 @@ impl Stream {
 
     /// Get average stream frame rate.
     pub fn avg_frame_rate(&self) -> Option<Rational> {
-        let mut num = 0_i32;
-        let mut den = 0_i32;
+        let mut num = 0;
+        let mut den = 0;
 
         unsafe {
             ffw_stream_get_avg_frame_rate(self.ptr, &mut num, &mut den);

--- a/src/format/stream.rs
+++ b/src/format/stream.rs
@@ -12,6 +12,7 @@ use crate::{
 
 extern "C" {
     fn ffw_stream_get_time_base(stream: *const c_void, num: *mut u32, den: *mut u32);
+    fn ffw_stream_get_frame_rate(stream: *const c_void, num: *mut u32, den: *mut u32);
     fn ffw_stream_get_start_time(stream: *const c_void) -> i64;
     fn ffw_stream_get_duration(stream: *const c_void) -> i64;
     fn ffw_stream_get_nb_frames(stream: *const c_void) -> i64;
@@ -46,6 +47,18 @@ impl Stream {
     /// Get stream time base.
     pub fn time_base(&self) -> TimeBase {
         self.time_base
+    }
+
+    /// Get stream frame rate.
+    pub fn frame_rate(&self) -> TimeBase {
+        let mut num = 0_u32;
+        let mut den = 0_u32;
+
+        unsafe {
+            ffw_stream_get_frame_rate(self.ptr, &mut num, &mut den);
+        }
+
+        TimeBase::new(num, den)
     }
 
     /// Get the pts of the first frame of the stream in presentation order.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub mod time;
 
 use std::{
     ffi::CStr,
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     io,
     os::raw::{c_char, c_int},
     sync::RwLock,
@@ -158,3 +158,34 @@ impl Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+/// A rational number with numerator num and denominator den (num/den).
+#[derive(Copy, Clone)]
+pub struct Rational {
+    num: i32,
+    den: i32,
+}
+
+impl Rational {
+    /// Create a rational number with a given numerator and
+    /// denominator.
+    pub const fn new(num: i32, den: i32) -> Self {
+        Self { num, den }
+    }
+
+    /// Get the numerator.
+    pub fn num(&self) -> i32 {
+        self.num
+    }
+
+    /// Get the denominator.
+    pub fn den(&self) -> i32 {
+        self.den
+    }
+}
+
+impl Debug for Rational {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}/{}", self.num(), self.den())
+    }
+}

--- a/src/time.c
+++ b/src/time.c
@@ -1,7 +1,7 @@
 #include <libavutil/avutil.h>
 #include <libavutil/mathematics.h>
 
-int64_t ffw_rescale_q(int64_t n, uint32_t aq_num, uint32_t aq_den, uint32_t bq_num, uint32_t bq_den) {
+int64_t ffw_rescale_q(int64_t n, int aq_num, int aq_den, int bq_num, int bq_den) {
     int64_t a = aq_num * (int64_t)bq_den;
     int64_t b = bq_num * (int64_t)aq_den;
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,11 +1,14 @@
 //! Time base aware timestamps.
 
 use std::{
+    borrow::Borrow,
     cmp::{Eq, Ordering, PartialEq, PartialOrd},
     fmt::{self, Debug, Formatter},
-    ops::{Add, AddAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Deref, Sub, SubAssign},
     time::Duration,
 };
+
+use crate::Rational;
 
 extern "C" {
     fn ffw_rescale_q(n: i64, aq_num: u32, aq_den: u32, bq_num: u32, bq_den: u32) -> i64;
@@ -15,8 +18,7 @@ extern "C" {
 /// A rational time base (e.g. 1/1000 is a millisecond time base).
 #[derive(Copy, Clone)]
 pub struct TimeBase {
-    num: u32,
-    den: u32,
+    rational: Rational,
 }
 
 impl TimeBase {
@@ -26,23 +28,51 @@ impl TimeBase {
     /// Create a new time base as a rational number with a given numerator and
     /// denominator.
     pub const fn new(num: u32, den: u32) -> Self {
-        Self { num, den }
+        Self {
+            rational: Rational::new(num as i32, den as i32),
+        }
     }
 
     /// Get the numerator.
     pub fn num(&self) -> u32 {
-        self.num
+        self.rational.num() as u32
     }
 
     /// Get the denominator.
     pub fn den(&self) -> u32 {
-        self.den
+        self.rational.den() as u32
+    }
+}
+
+impl AsRef<Rational> for TimeBase {
+    fn as_ref(&self) -> &Rational {
+        &self.rational
+    }
+}
+
+impl Borrow<Rational> for TimeBase {
+    fn borrow(&self) -> &Rational {
+        &self.rational
+    }
+}
+
+impl Deref for TimeBase {
+    type Target = Rational;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rational
+    }
+}
+
+impl From<Rational> for TimeBase {
+    fn from(rational: Rational) -> Self {
+        TimeBase { rational }
     }
 }
 
 impl Debug for TimeBase {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{}/{}", self.num(), self.den())
+        write!(f, "{:?}", self.rational)
     }
 }
 
@@ -117,10 +147,10 @@ impl Timestamp {
             unsafe {
                 ffw_rescale_q(
                     self.timestamp,
-                    self.time_base.num,
-                    self.time_base.den,
-                    time_base.num,
-                    time_base.den,
+                    self.time_base.num(),
+                    self.time_base.den(),
+                    time_base.num(),
+                    time_base.den(),
                 )
             }
         };

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,13 +5,13 @@ use std::{
     cmp::{Eq, Ordering, PartialEq, PartialOrd},
     fmt::{self, Debug, Formatter},
     ops::{Add, AddAssign, Deref, Sub, SubAssign},
-    time::Duration,
+    time::Duration, os::raw::c_int,
 };
 
 use crate::Rational;
 
 extern "C" {
-    fn ffw_rescale_q(n: i64, aq_num: u32, aq_den: u32, bq_num: u32, bq_den: u32) -> i64;
+    fn ffw_rescale_q(n: i64, aq_num: c_int, aq_den: c_int, bq_num: c_int, bq_den: c_int) -> i64;
     fn ffw_null_timestamp() -> i64;
 }
 
@@ -27,20 +27,10 @@ impl TimeBase {
 
     /// Create a new time base as a rational number with a given numerator and
     /// denominator.
-    pub const fn new(num: u32, den: u32) -> Self {
+    pub const fn new(num: i32, den: i32) -> Self {
         Self {
-            rational: Rational::new(num as i32, den as i32),
+            rational: Rational::new(num, den),
         }
-    }
-
-    /// Get the numerator.
-    pub fn num(&self) -> u32 {
-        self.rational.num() as u32
-    }
-
-    /// Get the denominator.
-    pub fn den(&self) -> u32 {
-        self.rational.den() as u32
     }
 }
 


### PR DESCRIPTION
Getting the frame rate of a stream works essentially the same way as getting the time base.
I'm unsure about whether it makes sense to introduce a new type, as `TimeBase` basically already resembles the `AVRational` type.
If anything, it might make sense to rename `TimeBase` to a shared `Rational` type and make `TimeBase` an alias of `Rational`.