### PR TITLE
Add raw packet timestamps, add ability to set timestamps

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -105,6 +105,13 @@ impl PacketMut {
         self
     }
 
+    /// Set packet presentation timestamp without time base.
+    pub fn with_raw_pts(self, pts: i64) -> Self {
+        unsafe { ffw_packet_set_pts(self.ptr, pts) }
+
+        self
+    }
+
     /// Get packet decoding timestamp.
     pub fn dts(&self) -> Timestamp {
         let dts = unsafe { ffw_packet_get_dts(self.ptr) };
@@ -117,6 +124,13 @@ impl PacketMut {
         let dts = dts.with_time_base(self.time_base);
 
         unsafe { ffw_packet_set_dts(self.ptr, dts.timestamp()) }
+
+        self
+    }
+
+    /// Set packet decoding timestamp without time base.
+    pub fn with_raw_dts(self, dts: i64) -> Self {
+        unsafe { ffw_packet_set_dts(self.ptr, dts) }
 
         self
     }
@@ -259,6 +273,13 @@ impl Packet {
         self
     }
 
+    /// Set packet presentation timestamp without time base.
+    pub fn with_raw_pts(self, pts: i64) -> Self {
+        unsafe { ffw_packet_set_pts(self.ptr, pts) }
+
+        self
+    }
+
     /// Get packet decoding timestamp.
     pub fn dts(&self) -> Timestamp {
         let dts = unsafe { ffw_packet_get_dts(self.ptr) };
@@ -271,6 +292,13 @@ impl Packet {
         let dts = dts.with_time_base(self.time_base);
 
         unsafe { ffw_packet_set_dts(self.ptr, dts.timestamp()) }
+
+        self
+    }
+
+    /// Set packet decoding timestamp without time base.
+    pub fn with_raw_dts(self, dts: i64) -> Self {
+        unsafe { ffw_packet_set_dts(self.ptr, dts) }
 
         self
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -103,6 +103,13 @@ impl Timestamp {
         self.timestamp
     }
 
+    /// Set the timestamp with the current time base.
+    pub fn with_new_timestamp(mut self, timestamp: i64) -> Self {
+        self.timestamp = timestamp;
+
+        self
+    }
+
     /// Check if this is the "null" timestamp (i.e. it is equal to the
     /// AV_NOPTS_VALUE).
     pub fn is_null(&self) -> bool {

--- a/src/time.rs
+++ b/src/time.rs
@@ -104,7 +104,7 @@ impl Timestamp {
     }
 
     /// Set the timestamp with the current time base.
-    pub fn with_new_timestamp(mut self, timestamp: i64) -> Self {
+    pub fn with_raw_timestamp(mut self, timestamp: i64) -> Self {
         self.timestamp = timestamp;
 
         self


### PR DESCRIPTION
Related to #38 . 
I also added the function to set timestamps without re-creating them. 

Basically this:
`let dts = Timestamp::new(10_000, packet.dts().time_base());` 
becomes this:
 `let dts = packet.dts().with_new_timestamp(10_000);` . 
 Not sure whether it's needed, but looks more elegant :) 