### PR TITLE
Expose best_effort_timestamp AVFrame field

### DIFF
--- a/src/codec/frame.c
+++ b/src/codec/frame.c
@@ -150,6 +150,10 @@ uint64_t ffw_frame_get_channel_layout(const AVFrame* frame) {
     return frame->channel_layout;
 }
 
+int64_t ffw_frame_get_best_effort_timestamp(const AVFrame* frame) {
+    return frame->best_effort_timestamp;
+}
+
 int64_t ffw_frame_get_pts(const AVFrame* frame) {
     return frame->pts;
 }

--- a/src/codec/video/frame.rs
+++ b/src/codec/video/frame.rs
@@ -22,6 +22,7 @@ extern "C" {
     fn ffw_frame_get_format(frame: *const c_void) -> c_int;
     fn ffw_frame_get_width(frame: *const c_void) -> c_int;
     fn ffw_frame_get_height(frame: *const c_void) -> c_int;
+    fn ffw_frame_get_best_effort_timestamp(frame: *const c_void) -> i64;
     fn ffw_frame_get_pts(frame: *const c_void) -> i64;
     fn ffw_frame_set_pts(frame: *mut c_void, pts: i64);
     fn ffw_frame_get_plane_data(frame: *mut c_void, index: usize) -> *mut u8;
@@ -460,6 +461,13 @@ impl VideoFrame {
         self.time_base = time_base;
 
         self
+    }
+
+    /// Get timestamp estimated using various heuristics.
+    pub fn best_effort_timestamp(&self) -> Timestamp {
+        let pts = unsafe { ffw_frame_get_best_effort_timestamp(self.ptr) };
+
+        Timestamp::new(pts, self.time_base)
     }
 
     /// Get presentation timestamp.


### PR DESCRIPTION
Hello! I found it useful to have access to the `best_effort_timestamp` field of `AVFrame` struct.

This field is useful, for example, in the following process (decode and then encode):
from
```
Input #0, avi, from '/tmp/sample.avi':
  Duration: 00:00:30.61, start: 0.000000, bitrate: 595 kb/s
  Stream #0:0: Video: h264 (High) (H264 / 0x34363248), yuv420p(progressive), 1920x1080 [SAR 1:1 DAR 16:9], 447 kb/s, 30 fps, 30 tbr, 30 tbn
  Stream #0:1: Audio: aac (LC) ([255][0][0][0] / 0x00FF), 48000 Hz, stereo, fltp, 139 kb/s
```
to
```
Output #0, mp4, to '/tmp/result.mp4':
  Stream #0:0: Video: h264, yuv420p, 1920x1080, q=2-31, 30 tbn
  Stream #0:1: Audio: aac (LC), 48000 Hz, stereo, fltp, 139 kb/s
```

In this case, without using `best_effort_timestamp` field, the decoded frame `pts` field is not set (`AV_NOPTS_VALUE`), the resulting video file is broken and we have the following output of FFmpeg:
```
[libx264 @ 0x55b7dd023600] non-strictly-monotonic PTS
[libx264 @ 0x55b7dd023600] non-strictly-monotonic PTS
...
[libx264 @ 0x55b7dd023600] non-strictly-monotonic PTS
[mp4 @ 0x55b7dcfd0780] Timestamps are unset in a packet for stream 0. This is deprecated and will stop working in the future. Fix your code to set the timestamps properly
[mp4 @ 0x55a01bd03980] pts has no value
[libx264 @ 0x55a01bd20580] non-strictly-monotonic PTS
...
[mp4 @ 0x55a01bd03980] pts has no value
[libx264 @ 0x55a01bd20580] non-strictly-monotonic PTS
...
```

It would be great if you add the ability to get the value of the `best_effort_timestamp` field, so that we can use it.