### PR TITLE
Add the ability to provide a hint to the muxer about the desired timebase

### DIFF
--- a/src/format/stream.c
+++ b/src/format/stream.c
@@ -12,6 +12,11 @@ void ffw_stream_get_time_base(const AVStream* stream, uint32_t* num, uint32_t* d
     *den = stream->time_base.den;
 }
 
+void ffw_stream_set_time_base(AVStream* stream, uint32_t num, uint32_t den) {
+    stream->time_base.num = num;
+    stream->time_base.den = den;
+}
+
 int64_t ffw_stream_get_start_time(const AVStream* stream) {
     return stream->start_time;
 }

--- a/src/format/stream.rs
+++ b/src/format/stream.rs
@@ -12,6 +12,7 @@ use crate::{
 
 extern "C" {
     fn ffw_stream_get_time_base(stream: *const c_void, num: *mut u32, den: *mut u32);
+    fn ffw_stream_set_time_base(stream: *const c_void, num: u32, den: u32);
     fn ffw_stream_get_start_time(stream: *const c_void) -> i64;
     fn ffw_stream_get_duration(stream: *const c_void) -> i64;
     fn ffw_stream_get_nb_frames(stream: *const c_void) -> i64;
@@ -46,6 +47,14 @@ impl Stream {
     /// Get stream time base.
     pub fn time_base(&self) -> TimeBase {
         self.time_base
+    }
+
+    /// Provide a hint to the muxer about the desired timebase.
+    pub fn set_time_base(&mut self, time_base: TimeBase) {
+        self.time_base = time_base;
+        unsafe {
+            ffw_stream_set_time_base(self.ptr, self.time_base.num(), self.time_base.den());
+        }
     }
 
     /// Get the pts of the first frame of the stream in presentation order.

--- a/src/format/stream.rs
+++ b/src/format/stream.rs
@@ -12,7 +12,7 @@ use crate::{
 
 extern "C" {
     fn ffw_stream_get_time_base(stream: *const c_void, num: *mut u32, den: *mut u32);
-    fn ffw_stream_set_time_base(stream: *const c_void, num: u32, den: u32);
+    fn ffw_stream_set_time_base(stream: *mut c_void, num: u32, den: u32);
     fn ffw_stream_get_start_time(stream: *const c_void) -> i64;
     fn ffw_stream_get_duration(stream: *const c_void) -> i64;
     fn ffw_stream_get_nb_frames(stream: *const c_void) -> i64;


### PR DESCRIPTION
Hello! I found it useful to have the ability to provide a hint to the muxer about the desired timebase.

This is useful, for example, when transmuxing to MP4 container. If the timebase of the input stream differs from the output, then when transferring the timestamp from one timebase to another due to inaccuracy of calculations there may be two different packets with the same dts/pts at the output. Which will result in an error message from FFmpeg:
```
[mp4 @ 0x7ff150113f40] Application provided invalid, non monotonically increasing dts to muxer in stream 0: 1538093 >= 1538093
```