### PR TITLE
Fix includes for new FFMPEG versions (5.1.2)

### DIFF
--- a/src/format/io.c
+++ b/src/format/io.c
@@ -1,4 +1,5 @@
 #include <libavformat/avio.h>
+#include <libavutil/mem.h>
 
 typedef int read_packet_t(void*, uint8_t*, int);
 typedef int write_packet_t(void*, uint8_t*, int);

--- a/src/logger.c
+++ b/src/logger.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <libavutil/log.h>
 
 #ifdef __GNUC__


### PR DESCRIPTION
Not sure which FFMPEG version made these necessary but shouldn't cause any issue with older versions. Especially the first commit is important to prevent a segfault when using this crate. (see commit message)