### PR TITLE
Add try_into_mut and into_mut for VideoFrame and AudioFrame

### DIFF
--- a/src/codec/audio/frame.rs
+++ b/src/codec/audio/frame.rs
@@ -504,11 +504,11 @@ impl AudioFrame {
     /// into mutable without copying the data, otherwise returns AudioFrame.
     pub fn try_into_mut(self) -> Result<AudioFrameMut, AudioFrame> {
         let res = unsafe { ffw_frame_is_writable(self.ptr) };
-        return if res > 0 {
+        if res > 0 {
             Ok(self.into_mut())
         } else {
             Err(self)
-        };
+        }
     }
 
     /// Make this frame mutable. This will copy the data if it is not already

--- a/src/codec/audio/frame.rs
+++ b/src/codec/audio/frame.rs
@@ -39,6 +39,8 @@ extern "C" {
     fn ffw_frame_get_line_size(frame: *const c_void, plane: usize) -> usize;
     fn ffw_frame_clone(frame: *const c_void) -> *mut c_void;
     fn ffw_frame_free(frame: *mut c_void);
+    fn ffw_frame_is_writable(frame: *const c_void) -> c_int;
+    fn ffw_frame_make_writable(frame: *mut c_void) -> c_int;
 }
 
 /// An error indicating an unknown channel layout.
@@ -496,6 +498,36 @@ impl AudioFrame {
     /// Get raw pointer.
     pub(crate) fn as_ptr(&self) -> *const c_void {
         self.ptr
+    }
+
+    /// Try to make this frame mutable. Returns AudioFrameMut if it can be made
+    /// into mutable without copying the data, otherwise returns AudioFrame.
+    pub fn try_into_mut(self) -> Result<AudioFrameMut, AudioFrame> {
+        let res = unsafe { ffw_frame_is_writable(self.ptr) };
+        return if res > 0 {
+            Ok(self.into_mut())
+        } else {
+            Err(self)
+        };
+    }
+
+    /// Make this frame mutable. This will copy the data if it is not already
+    /// mutable.
+    pub fn into_mut(mut self) -> AudioFrameMut {
+        let res = unsafe { ffw_frame_make_writable(self.ptr) };
+
+        if res < 0 {
+            panic!("unable to make the frame mutable");
+        }
+
+        let ptr = self.ptr;
+
+        self.ptr = ptr::null_mut();
+
+        AudioFrameMut {
+            ptr,
+            time_base: self.time_base,
+        }
     }
 }
 

--- a/src/codec/frame.c
+++ b/src/codec/frame.c
@@ -191,7 +191,7 @@ uint8_t* ffw_frame_get_plane_data(AVFrame* frame, size_t index) {
 }
 
 int ffw_frame_is_writable(const AVFrame* frame) {
-    return av_frame_is_writable(frame);
+    return av_frame_is_writable((AVFrame*)frame);
 }
 
 int ffw_frame_make_writable(AVFrame* frame) {

--- a/src/codec/frame.c
+++ b/src/codec/frame.c
@@ -189,3 +189,11 @@ size_t ffw_frame_get_line_count(const AVFrame* frame, size_t plane) {
 uint8_t* ffw_frame_get_plane_data(AVFrame* frame, size_t index) {
     return frame->extended_data[index];
 }
+
+int ffw_frame_is_writable(const AVFrame* frame) {
+    return av_frame_is_writable(frame);
+}
+
+int ffw_frame_make_writable(AVFrame* frame) {
+    return av_frame_make_writable(frame);
+}

--- a/src/codec/video/frame.rs
+++ b/src/codec/video/frame.rs
@@ -497,11 +497,11 @@ impl VideoFrame {
     /// into mutable without copying the data, otherwise returns VideoFrame.
     pub fn try_into_mut(self) -> Result<VideoFrameMut, VideoFrame> {
         let res = unsafe { ffw_frame_is_writable(self.ptr) };
-        return if res > 0 {
+        if res > 0 {
             Ok(self.into_mut())
         } else {
             Err(self)
-        };
+        }
     }
 
     /// Make this frame mutable. This will copy the data if it is not already


### PR DESCRIPTION
As per the discussion in #47 , two methods `try_into_mut` and `into_mut` are implemented for `VideoFrame` and `AudioFrame`. I'm pretty new to Rust and FFmpeg so let me know if I did something wrong.