### PR TITLE
Expose picture_type for frames

### DIFF
--- a/src/codec/frame.c
+++ b/src/codec/frame.c
@@ -197,3 +197,11 @@ int ffw_frame_is_writable(const AVFrame* frame) {
 int ffw_frame_make_writable(AVFrame* frame) {
     return av_frame_make_writable(frame);
 }
+
+int ffw_frame_get_picture_type(const AVFrame* frame) {
+    return frame->pict_type;
+}
+
+void ffw_frame_set_picture_type(AVFrame* frame, int picture_type) {
+    frame->pict_type = picture_type;
+}

--- a/src/codec/frame.c
+++ b/src/codec/frame.c
@@ -213,15 +213,18 @@ int ffw_frame_get_picture_type(const AVFrame* frame) {
 }
 
 void ffw_frame_set_picture_type(AVFrame* frame, int picture_type) {
-    enum AVPictureType type = AV_PICTURE_TYPE_NONE;
+    enum AVPictureType type;
+
     switch(picture_type) {
-    case 1: type = AV_PICTURE_TYPE_I; break;
-    case 2: type = AV_PICTURE_TYPE_P; break;
-    case 3: type = AV_PICTURE_TYPE_B; break;
-    case 4: type = AV_PICTURE_TYPE_S; break;
-    case 5: type = AV_PICTURE_TYPE_SI; break;
-    case 6: type = AV_PICTURE_TYPE_SP; break;
-    case 7: type = AV_PICTURE_TYPE_BI; break;
+        case 1: type = AV_PICTURE_TYPE_I; break;
+        case 2: type = AV_PICTURE_TYPE_P; break;
+        case 3: type = AV_PICTURE_TYPE_B; break;
+        case 4: type = AV_PICTURE_TYPE_S; break;
+        case 5: type = AV_PICTURE_TYPE_SI; break;
+        case 6: type = AV_PICTURE_TYPE_SP; break;
+        case 7: type = AV_PICTURE_TYPE_BI; break;
+        default: type = AV_PICTURE_TYPE_NONE; break;
     }
+
     frame->pict_type = type;
 }

--- a/src/codec/frame.c
+++ b/src/codec/frame.c
@@ -201,15 +201,15 @@ int ffw_frame_make_writable(AVFrame* frame) {
 
 int ffw_frame_get_picture_type(const AVFrame* frame) {
     switch (frame->pict_type) {
-    case AV_PICTURE_TYPE_I: return 1;
-    case AV_PICTURE_TYPE_P: return 2;
-    case AV_PICTURE_TYPE_B: return 3;
-    case AV_PICTURE_TYPE_S: return 4;
-    case AV_PICTURE_TYPE_SI: return 5;
-    case AV_PICTURE_TYPE_SP: return 6;
-    case AV_PICTURE_TYPE_BI: return 7;
+        case AV_PICTURE_TYPE_I: return 1;
+        case AV_PICTURE_TYPE_P: return 2;
+        case AV_PICTURE_TYPE_B: return 3;
+        case AV_PICTURE_TYPE_S: return 4;
+        case AV_PICTURE_TYPE_SI: return 5;
+        case AV_PICTURE_TYPE_SP: return 6;
+        case AV_PICTURE_TYPE_BI: return 7;
+        default: return 0;
     }
-    return 0; // None
 }
 
 void ffw_frame_set_picture_type(AVFrame* frame, int picture_type) {

--- a/src/codec/frame.c
+++ b/src/codec/frame.c
@@ -4,6 +4,7 @@
 #include <libavutil/pixdesc.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/samplefmt.h>
+#include <libavutil/avutil.h>
 
 uint64_t ffw_get_channel_layout_by_name(const char* name) {
     return av_get_channel_layout(name);
@@ -199,9 +200,28 @@ int ffw_frame_make_writable(AVFrame* frame) {
 }
 
 int ffw_frame_get_picture_type(const AVFrame* frame) {
-    return frame->pict_type;
+    switch (frame->pict_type) {
+    case AV_PICTURE_TYPE_I: return 1;
+    case AV_PICTURE_TYPE_P: return 2;
+    case AV_PICTURE_TYPE_B: return 3;
+    case AV_PICTURE_TYPE_S: return 4;
+    case AV_PICTURE_TYPE_SI: return 5;
+    case AV_PICTURE_TYPE_SP: return 6;
+    case AV_PICTURE_TYPE_BI: return 7;
+    }
+    return 0; // None
 }
 
 void ffw_frame_set_picture_type(AVFrame* frame, int picture_type) {
-    frame->pict_type = picture_type;
+    enum AVPictureType type = AV_PICTURE_TYPE_NONE;
+    switch(picture_type) {
+    case 1: type = AV_PICTURE_TYPE_I; break;
+    case 2: type = AV_PICTURE_TYPE_P; break;
+    case 3: type = AV_PICTURE_TYPE_B; break;
+    case 4: type = AV_PICTURE_TYPE_S; break;
+    case 5: type = AV_PICTURE_TYPE_SI; break;
+    case 6: type = AV_PICTURE_TYPE_SP; break;
+    case 7: type = AV_PICTURE_TYPE_BI; break;
+    }
+    frame->pict_type = type;
 }

--- a/src/codec/video/frame.rs
+++ b/src/codec/video/frame.rs
@@ -56,17 +56,16 @@ pub enum PictureType {
 }
 
 impl PictureType {
-    pub fn from_i32(value: i32) -> Option<Self> {
+    pub(crate) fn from_raw(value: c_int) -> Self {
         match value {
-            0 => Some(PictureType::None),
-            1 => Some(PictureType::I),
-            2 => Some(PictureType::P),
-            3 => Some(PictureType::B),
-            4 => Some(PictureType::S),
-            5 => Some(PictureType::Si),
-            6 => Some(PictureType::Sp),
-            7 => Some(PictureType::Bi),
-            _ => None,
+            1 => PictureType::I,
+            2 => PictureType::P,
+            3 => PictureType::B,
+            4 => PictureType::S,
+            5 => PictureType::Si,
+            6 => PictureType::Sp,
+            7 => PictureType::Bi,
+            _ => PictureType::None,
         }
     }
 }
@@ -421,12 +420,12 @@ impl VideoFrameMut {
 
     /// Get picture type
     pub fn picture_type(&self) -> PictureType {
-        unsafe { PictureType::from_i32(ffw_frame_get_picture_type(self.ptr)).unwrap() }
+        unsafe { PictureType::from_raw(ffw_frame_get_picture_type(self.ptr)) }
     }
 
     /// Set picture type
     pub fn with_picture_type(self, picture_type: PictureType) -> Self {
-        unsafe { ffw_frame_set_picture_type(self.ptr, picture_type as i32) };
+        unsafe { ffw_frame_set_picture_type(self.ptr, picture_type as c_int) };
         self
     }
 
@@ -538,7 +537,7 @@ impl VideoFrame {
 
     /// Get picture type
     pub fn picture_type(&self) -> PictureType {
-        unsafe { PictureType::from_i32(ffw_frame_get_picture_type(self.ptr)).unwrap() }
+        unsafe { PictureType::from_raw(ffw_frame_get_picture_type(self.ptr)) }
     }
 
     /// Get raw pointer.


### PR DESCRIPTION
This PR exposes `picture_type` to users so they can force an I frame when needed. e.g. streaming apps might want to send an I frame when there is a new user joining so they could start decoding immediately.

Please let me know if I did anything wrong!