### PR TITLE
QoL: Optionally use overloaded env vars per target

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ files and libraries:
 * `FFMPEG_INCLUDE_DIR` - path to the FFmpeg header files
 * `FFMPEG_LIB_DIR` - path to the FFmpeg libs
 
+If you require building for multiple platforms, you can append `_PLATFORM_TARGET_TRIPLET` to both of the above to create platform specific env. variables, for example:
+* `FFMPEG_INCLUDE_DIR_AARCH64_LINUX_ANDROID = ${jniInclude}/arm64-v8a/`
+* `FFMPEG_LIB_DIR_AARCH64_LINUX_ANDROID     = ${jniLibs}/arm64-v8a/`
+* `FFMPEG_INCLUDE_DIR_X86_64_LINUX_ANDROID = ${jniInclude}/x86_64/`
+* `FFMPEG_LIB_DIR_X86_64_LINUX_ANDROID     = ${jniLibs}/x86_64/`
+
 If you prefer static linking, you can force it using:
 
 * `FFMPEG_STATIC=1`

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 use std::{
     env,
-    fmt::format,
     path::{Path, PathBuf},
     process::Command,
 };

--- a/build.rs
+++ b/build.rs
@@ -58,11 +58,21 @@ fn main() {
 }
 
 fn ffmpeg_include_dirs() -> Vec<PathBuf> {
-    if let Ok(dir) = env::var("FFMPEG_INCLUDE_DIR") {
-        let dir = PathBuf::from(dir);
+    if let Some(target) = normalized_target() {
+        if let Ok(dir) = env::var(&format!("FFMPEG_INCLUDE_DIR_{}", target)) {
+            let dir = PathBuf::from(dir);
 
-        if dir.is_dir() {
-            return vec![dir];
+            if dir.is_dir() {
+                return vec![dir];
+            }
+        }
+    } else {
+        if let Ok(dir) = env::var("FFMPEG_INCLUDE_DIR") {
+            let dir = PathBuf::from(dir);
+
+            if dir.is_dir() {
+                return vec![dir];
+            }
         }
     }
 
@@ -78,11 +88,21 @@ fn ffmpeg_include_dirs() -> Vec<PathBuf> {
 }
 
 fn ffmpeg_lib_dirs() -> Vec<PathBuf> {
-    if let Ok(dir) = env::var("FFMPEG_LIB_DIR") {
-        let dir = PathBuf::from(dir);
+    if let Some(target) = normalized_target() {
+        if let Ok(dir) = env::var(&format!("FFMPEG_LIB_DIR_{}", target)) {
+            let dir = PathBuf::from(dir);
 
-        if dir.is_dir() {
-            return vec![dir];
+            if dir.is_dir() {
+                return vec![dir];
+            }
+        }
+    } else {
+        if let Ok(dir) = env::var("FFMPEG_LIB_DIR") {
+            let dir = PathBuf::from(dir);
+
+            if dir.is_dir() {
+                return vec![dir];
+            }
         }
     }
 
@@ -95,6 +115,12 @@ fn ffmpeg_lib_dirs() -> Vec<PathBuf> {
         .expect("Unable to find FFmpeg lib dir. You can specify it explicitly by setting the FFMPEG_LIB_DIR environment variable.");
 
     lib.link_paths
+}
+
+fn normalized_target() -> Option<String> {
+    env::var("TARGET")
+        .ok()
+        .map(|t| t.to_uppercase().replace('-', "_"))
 }
 
 fn link_static(lib: &str) {

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 use std::{
     env,
+    fmt::format,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -66,13 +67,11 @@ fn ffmpeg_include_dirs() -> Vec<PathBuf> {
                 return vec![dir];
             }
         }
-    } else {
-        if let Ok(dir) = env::var("FFMPEG_INCLUDE_DIR") {
-            let dir = PathBuf::from(dir);
+    } else if let Ok(dir) = env::var("FFMPEG_INCLUDE_DIR") {
+        let dir = PathBuf::from(dir);
 
-            if dir.is_dir() {
-                return vec![dir];
-            }
+        if dir.is_dir() {
+            return vec![dir];
         }
     }
 
@@ -96,13 +95,11 @@ fn ffmpeg_lib_dirs() -> Vec<PathBuf> {
                 return vec![dir];
             }
         }
-    } else {
-        if let Ok(dir) = env::var("FFMPEG_LIB_DIR") {
-            let dir = PathBuf::from(dir);
+    } else if let Ok(dir) = env::var("FFMPEG_LIB_DIR") {
+        let dir = PathBuf::from(dir);
 
-            if dir.is_dir() {
-                return vec![dir];
-            }
+        if dir.is_dir() {
+            return vec![dir];
         }
     }
 


### PR DESCRIPTION
this is required so that I can do the following in gradle

```
cargoNdk {
    targets = ["arm64", "x86_64"] 
    extraCargoEnv = [
            "..."                                     : "....",
            "FFMPEG_INCLUDE_DIR_AARCH64_LINUX_ANDROID": "${jniInclude}/arm64-v8a/",
            "FFMPEG_LIB_DIR_AARCH64_LINUX_ANDROID"    : "${jniLibs}/arm64-v8a/",
            "FFMPEG_INCLUDE_DIR_X86_64_LINUX_ANDROID" : "${jniInclude}/x86_64/",
            "FFMPEG_LIB_DIR_X86_64_LINUX_ANDROID"     : "${jniLibs}/x86_64/"]
}
```

cargoNdk does not support per-target env vars. Took the idea from tflitec-rs