### PR TITLE
Fix build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -66,7 +66,9 @@ fn ffmpeg_include_dirs() -> Vec<PathBuf> {
                 return vec![dir];
             }
         }
-    } else if let Ok(dir) = env::var("FFMPEG_INCLUDE_DIR") {
+    }
+
+    if let Ok(dir) = env::var("FFMPEG_INCLUDE_DIR") {
         let dir = PathBuf::from(dir);
 
         if dir.is_dir() {
@@ -94,7 +96,9 @@ fn ffmpeg_lib_dirs() -> Vec<PathBuf> {
                 return vec![dir];
             }
         }
-    } else if let Ok(dir) = env::var("FFMPEG_LIB_DIR") {
+    }
+
+    if let Ok(dir) = env::var("FFMPEG_LIB_DIR") {
         let dir = PathBuf::from(dir);
 
         if dir.is_dir() {


### PR DESCRIPTION
Currently if the environment variable `FFMPEG_INCLUDE_DIR_TARGET` or `FFMPEG_LIB_DIR_TARGET` is not found, then `FFMPEG_INCLUDE_DIR` or `FFMPEG_LIB_DIR` will not be checked next and the build will fail even if `FFMPEG_INCLUDE_DIR` and `FFMPEG_LIB_DIR` are specified correctly.
This PR fixed it.