### PR TITLE
Expose stream side data

### DIFF
--- a/ac-ffmpeg/src/format/stream.c
+++ b/ac-ffmpeg/src/format/stream.c
@@ -58,3 +58,25 @@ int ffw_stream_set_metadata(AVStream* stream, const char* key, const char* value
 void ffw_stream_set_id(AVStream* stream, int id) {
     stream->id = id;
 }
+
+size_t ffw_stream_get_nb_side_data(const AVStream* stream) {
+    return stream->nb_side_data;
+}
+
+const AVPacketSideData* ffw_stream_get_side_data(const AVStream* stream, size_t index) {
+    return &stream->side_data[index];
+}
+
+int ffw_stream_add_side_data(AVStream* stream, enum AVPacketSideDataType data_type, uint8_t* data, size_t size) {
+    void* dup_data = av_memdup(data, size);
+    if (!dup_data) {
+        return AVERROR(ENOMEM);
+    }
+
+    int ret = av_stream_add_side_data(stream, data_type, dup_data, size);
+    if (ret < 0) {
+        av_free(dup_data);
+    }
+
+    return ret;
+}

--- a/ac-ffmpeg/src/packet.c
+++ b/ac-ffmpeg/src/packet.c
@@ -92,3 +92,19 @@ int ffw_packet_is_writable(const AVPacket* packet) {
 int ffw_packet_make_writable(AVPacket* packet) {
     return av_packet_make_writable(packet);
 }
+
+size_t ffw_packet_side_data_get_size(const AVPacketSideData* side_data) {
+    return side_data->size;
+}
+
+const uint8_t* ffw_packet_side_data_get_data(const AVPacketSideData* side_data) {
+    return side_data->data;
+}
+
+int ffw_packet_side_data_get_type(const AVPacketSideData* side_data) {
+    return side_data->type;
+}
+
+const char* ffw_packet_get_side_data_name(int side_data_type) {
+    return av_packet_side_data_name(side_data_type);
+}


### PR DESCRIPTION
Hello! I am faced with the following task, there is the video that has side data in one stream:
```bash
$ ffprobe video.mp4
...
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 1920x1080, 3186 kb/s, 30.03 fps, 30 tbr, 19200 tbn (default)
    Metadata:
      handler_name    : VideoHandler
      vendor_id       : [0][0][0][0]
    Side data:
      displaymatrix: rotation of -180.00 degrees

...
```
If you transcode such a video and don't copy the stream side data to the output video, the output video will be rotated relative to the source video.

To properly transcode such a video, you need to be able to copy the stream side data to the output video.