### PR TITLE
Expose codec tag

### DIFF
--- a/ac-ffmpeg/src/codec/audio/mod.rs
+++ b/ac-ffmpeg/src/codec/audio/mod.rs
@@ -7,7 +7,7 @@ pub mod transcoder;
 use std::{ffi::CString, os::raw::c_void, ptr};
 
 use crate::{
-    codec::{AudioCodecParameters, CodecError, CodecParameters, Decoder, Encoder},
+    codec::{AudioCodecParameters, CodecError, CodecParameters, CodecTag, Decoder, Encoder},
     format::stream::Stream,
     packet::Packet,
     time::TimeBase,
@@ -410,6 +410,15 @@ impl AudioEncoderBuilder {
     /// Set channel layout.
     pub fn channel_layout(mut self, layout: ChannelLayout) -> Self {
         self.channel_layout = Some(layout);
+        self
+    }
+
+    /// Set codec tag.
+    pub fn codec_tag(self, codec_tag: impl Into<CodecTag>) -> Self {
+        unsafe {
+            super::ffw_encoder_set_codec_tag(self.raw.ptr, codec_tag.into().into());
+        }
+
         self
     }
 

--- a/ac-ffmpeg/src/codec/mod.c
+++ b/ac-ffmpeg/src/codec/mod.c
@@ -130,6 +130,10 @@ const uint64_t * ffw_codec_parameters_get_channel_layout(const AVCodecParameters
 }
 #endif
 
+uint32_t ffw_codec_parameters_get_codec_tag(const AVCodecParameters* params) {
+    return params->codec_tag;
+}
+
 uint8_t* ffw_codec_parameters_get_extradata(AVCodecParameters* params) {
     return params->extradata;
 }
@@ -172,6 +176,10 @@ int ffw_codec_parameters_set_channel_layout(AVCodecParameters* params, const uin
     return 0;
 }
 #endif
+
+void ffw_codec_parameters_set_codec_tag(AVCodecParameters* params, uint32_t codec_tag) {
+    params->codec_tag = codec_tag;
+}
 
 int ffw_codec_parameters_set_extradata(AVCodecParameters* params, const uint8_t* extradata, int size) {
     if (params->extradata) {
@@ -417,6 +425,7 @@ void ffw_encoder_set_width(Encoder* encoder, int width);
 void ffw_encoder_set_height(Encoder* encoder, int height);
 void ffw_encoder_set_sample_format(Encoder* encoder, int format);
 void ffw_encoder_set_sample_rate(Encoder* encoder, int sample_rate);
+void ffw_encoder_set_codec_tag(Encoder* encoder, uint32_t codec_tag);
 int ffw_encoder_set_initial_option(Encoder* encoder, const char* key, const char* value);
 int ffw_encoder_open(Encoder* encoder);
 int ffw_encoder_push_frame(Encoder* encoder, const AVFrame* frame);
@@ -603,6 +612,10 @@ int ffw_encoder_set_channel_layout(Encoder* encoder, const uint64_t* layout) {
     return 0;
 }
 #endif
+
+void ffw_encoder_set_codec_tag(Encoder* encoder, uint32_t codec_tag) {
+    encoder->cc->codec_tag = codec_tag;
+}
 
 int ffw_encoder_set_initial_option(Encoder* encoder, const char* key, const char* value) {
     return av_dict_set(&encoder->options, key, value, 0);

--- a/ac-ffmpeg/src/codec/video/mod.rs
+++ b/ac-ffmpeg/src/codec/video/mod.rs
@@ -6,7 +6,7 @@ pub mod scaler;
 use std::{ffi::CString, os::raw::c_void, ptr};
 
 use crate::{
-    codec::{CodecError, CodecParameters, Decoder, Encoder, VideoCodecParameters},
+    codec::{CodecError, CodecParameters, CodecTag, Decoder, Encoder, VideoCodecParameters},
     format::stream::Stream,
     packet::Packet,
     time::TimeBase,
@@ -380,6 +380,15 @@ impl VideoEncoderBuilder {
     /// Set frame height.
     pub fn height(mut self, height: usize) -> Self {
         self.height = Some(height);
+        self
+    }
+
+    /// Set codec tag.
+    pub fn codec_tag(self, codec_tag: impl Into<CodecTag>) -> Self {
+        unsafe {
+            super::ffw_encoder_set_codec_tag(self.ptr, codec_tag.into().into());
+        }
+
         self
     }
 


### PR DESCRIPTION
Hello! I'm faced with the following problem - I have the media file, this file has the video stream:
```bash
$ ffprobe video.mp4
...
Stream #0:0[0x1](und): Video: hevc (Main 10) (hvc1 / 0x31637668), yuv420p10le(tv, bt2020nc/bt2020/arib-std-b67), 720x1280, 10774 kb/s, 29.98 fps, 29.97 tbr, 600 tbn (default)
...
```
When I remux this media file, the codec tag of this stream changes, from `hvc1` to `hev1`.
```bash
$ ffprobe result.mp4
...
Stream #0:0[0x1](und): Video: hevc (Main 10) (hev1 / 0x31766568), yuv420p10le(tv, bt2020nc/bt2020/arib-std-b67), 720x1280, 10774 kb/s, 29.98 fps, 29.97 tbr, 90k tbn (default)
...
```
And the problem is compounded by the fact that the macOS is not friendly with `hev1` codec tag.
Source media file from the example above with `hvc1` codec tag is played in macOS, but not with the `hev1` codec tag.

I think it would be great to be able to control the codec tag.