### PR TITLE
expose input format name from demuxer

### DIFF
--- a/ac-ffmpeg/src/format/demuxer.c
+++ b/ac-ffmpeg/src/format/demuxer.c
@@ -44,6 +44,12 @@ AVInputFormat* ffw_guess_input_format(
     return (AVInputFormat*)res;
 }
 
+const char* ffw_input_format_name(
+    AVInputFormat* input_format
+) {
+    return input_format->name;
+}
+
 typedef struct Demuxer {
     AVFormatContext* fc;
     AVDictionary* options;
@@ -57,6 +63,7 @@ int ffw_demuxer_set_option(Demuxer* demuxer, const char* key, const char* value)
 int ffw_demuxer_find_stream_info(Demuxer* demuxer, int64_t max_analyze_duration);
 unsigned ffw_demuxer_get_nb_streams(const Demuxer* demuxer);
 AVStream* ffw_demuxer_get_stream(Demuxer* demuxer, unsigned stream_index);
+const struct AVInputFormat* ffw_demuxer_get_input_format(Demuxer* demuxer);
 int ffw_demuxer_read_frame(Demuxer* demuxer, AVPacket** packet, uint32_t* tb_num, uint32_t* tb_den);
 int ffw_demuxer_seek(Demuxer* demuxer, int64_t timestamp, int seek_by, int seek_target);
 void ffw_demuxer_free(Demuxer* demuxer);
@@ -131,6 +138,10 @@ unsigned ffw_demuxer_get_nb_streams(const Demuxer* demuxer) {
 
 AVStream* ffw_demuxer_get_stream(Demuxer* demuxer, unsigned stream_index) {
     return demuxer->fc->streams[stream_index];
+}
+
+const struct AVInputFormat* ffw_demuxer_get_input_format(Demuxer* demuxer) {
+    return demuxer->fc->iformat;
 }
 
 int ffw_demuxer_read_frame(Demuxer* demuxer, AVPacket** packet, uint32_t* tb_num, uint32_t* tb_den) {

--- a/ac-ffmpeg/src/format/demuxer.c
+++ b/ac-ffmpeg/src/format/demuxer.c
@@ -44,9 +44,7 @@ AVInputFormat* ffw_guess_input_format(
     return (AVInputFormat*)res;
 }
 
-const char* ffw_input_format_name(
-    AVInputFormat* input_format
-) {
+const char* ffw_input_format_name(const AVInputFormat* input_format) {
     return input_format->name;
 }
 

--- a/ac-ffmpeg/src/format/demuxer.c
+++ b/ac-ffmpeg/src/format/demuxer.c
@@ -63,7 +63,7 @@ int ffw_demuxer_set_option(Demuxer* demuxer, const char* key, const char* value)
 int ffw_demuxer_find_stream_info(Demuxer* demuxer, int64_t max_analyze_duration);
 unsigned ffw_demuxer_get_nb_streams(const Demuxer* demuxer);
 AVStream* ffw_demuxer_get_stream(Demuxer* demuxer, unsigned stream_index);
-const struct AVInputFormat* ffw_demuxer_get_input_format(Demuxer* demuxer);
+const AVInputFormat* ffw_demuxer_get_input_format(const Demuxer* demuxer);
 int ffw_demuxer_read_frame(Demuxer* demuxer, AVPacket** packet, uint32_t* tb_num, uint32_t* tb_den);
 int ffw_demuxer_seek(Demuxer* demuxer, int64_t timestamp, int seek_by, int seek_target);
 void ffw_demuxer_free(Demuxer* demuxer);

--- a/ac-ffmpeg/src/format/demuxer.c
+++ b/ac-ffmpeg/src/format/demuxer.c
@@ -138,7 +138,7 @@ AVStream* ffw_demuxer_get_stream(Demuxer* demuxer, unsigned stream_index) {
     return demuxer->fc->streams[stream_index];
 }
 
-const struct AVInputFormat* ffw_demuxer_get_input_format(Demuxer* demuxer) {
+const AVInputFormat* ffw_demuxer_get_input_format(const Demuxer* demuxer) {
     return demuxer->fc->iformat;
 }
 

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -335,7 +335,7 @@ impl<T> Demuxer<T> {
         Ok(res)
     }
 
-    pub fn get_input_format(self) -> InputFormat {
+    pub fn get_input_format(&self) -> InputFormat {
         unsafe {
             let input_format = ffw_demuxer_get_input_format(self.ptr);
             InputFormat { ptr: input_format }
@@ -469,7 +469,7 @@ impl InputFormat {
         Some(res)
     }
 
-    pub fn name(self) -> String {
+    pub fn name(&self) -> String {
         unsafe {
             let name = ffw_input_format_name(self.ptr);
 

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -45,7 +45,7 @@ extern "C" {
     fn ffw_demuxer_find_stream_info(demuxer: *mut c_void, max_analyze_duration: i64) -> c_int;
     fn ffw_demuxer_get_nb_streams(demuxer: *const c_void) -> c_uint;
     fn ffw_demuxer_get_stream(demuxer: *mut c_void, index: c_uint) -> *mut c_void;
-    fn ffw_demuxer_get_input_format(demuxer: *mut c_void) -> *mut c_void; // todo: const?
+    fn ffw_demuxer_get_input_format(demuxer: *const c_void) -> *const c_void;
     fn ffw_demuxer_read_frame(
         demuxer: *mut c_void,
         packet: *mut *mut c_void,

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -59,7 +59,7 @@ extern "C" {
         seek_target: c_int,
     ) -> c_int;
     fn ffw_demuxer_free(demuxer: *mut c_void);
-    fn ffw_input_format_name(input_format: *mut c_void) -> *const c_char;
+    fn ffw_input_format_name(input_format: *const c_void) -> *const c_char;
 }
 
 /// Seek type/mode.

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -483,16 +483,3 @@ impl InputFormat {
 
 unsafe impl Send for InputFormat {}
 unsafe impl Sync for InputFormat {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn get_format_name() {
-        let input_format =
-            InputFormat::guess_from_file_name("file.mp3").expect("to find input format");
-
-        assert_eq!(input_format.name(), "mp3");
-    }
-}

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -469,14 +469,11 @@ impl InputFormat {
         Some(res)
     }
 
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &str {
         unsafe {
-            let name = ffw_input_format_name(self.ptr);
-
-            CStr::from_ptr(name)
+            CStr::from_ptr(ffw_input_format_name(self.ptr))
                 .to_str()
                 .expect("invalid format name")
-                .to_string()
         }
     }
 }

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -335,13 +335,17 @@ impl<T> Demuxer<T> {
         Ok(res)
     }
 
-    pub fn get_input_format(&self) -> InputFormat {
+    pub fn input_format(&self) -> InputFormat {
+        // XXX: This is potentially very ugly as we rely on the fact that the
+        // input formats are statically allocated by FFmpeg and not owned by
+        // demuxers (and the underlying format contexts). In future versions,
+        // we should capture lifetime of the demuxer in the returned type.
         unsafe {
-            let input_format = ffw_demuxer_get_input_format(self.ptr);
-            InputFormat { ptr: input_format }
+            InputFormat {
+                ptr: ffw_demuxer_get_input_format(self.ptr) as _,
+            }
         }
     }
-
     /// Get reference to the underlying IO.
     pub fn io(&self) -> &IO<T> {
         &self.io

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -1,10 +1,9 @@
 //! A/V demuxer.
 
-use std::ffi::CStr;
 use std::{
     borrow::{Borrow, BorrowMut},
     convert::TryInto,
-    ffi::CString,
+    ffi::{CString, CStr},
     io::Read,
     ops::{Deref, DerefMut},
     os::raw::{c_char, c_int, c_uint, c_void},


### PR DESCRIPTION
It can be useful to be able to figure out what input format the demuxer ended up with, especially when doing format guessing.

In this PR I:

 - expose the input format on the demuxer
 - expose the [name](https://ffmpeg.org/doxygen/2.7/structAVInputFormat.html#a850db3eb225e22b64f3304d72134ca0c) of the input format