### PR TITLE
use pkg config on macos too

### DIFF
--- a/ac-ffmpeg-build/src/lib.rs
+++ b/ac-ffmpeg-build/src/lib.rs
@@ -37,7 +37,7 @@ pub fn ffmpeg_lib_dirs(env_metadata: bool) -> Vec<PathBuf> {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
+    if #[cfg(any(target_os = "linux", target_os = "macos"))] {
         use pkg_config::{Config, Library};
 
         /// Find a given library using pkg-config.


### PR DESCRIPTION
previously:

```
error: failed to run custom build command for `ac-ffmpeg-features v0.1.0`

Caused by:
  process didn't exit successfully: `[...snip...]/target/debug/build/ac-ffmpeg-features-61bfed659e0637da/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=FFMPEG_INCLUDE_DIR_X86_64_APPLE_DARWIN
  cargo:rerun-if-env-changed=FFMPEG_INCLUDE_DIR

  --- stderr
  thread 'main' panicked at 'Unable to find FFmpeg include dir. You can specify it explicitly by setting the FFMPEG_INCLUDE_DIR environment variable.', [...snip...]/ac-ffmpeg-build/src/lib.rs:16:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

with this change it correctly finds ffmpeg