### PR TITLE
Implement subtitle transcoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ interface.
 * Seeking
 * Decoding audio and video
 * Encoding audio and video
+* Transcoding subtitles
 * Video frame scaling and pixel format transformations
 * Audio resampling
 * Bitstream filters

--- a/ac-ffmpeg/build.rs
+++ b/ac-ffmpeg/build.rs
@@ -21,6 +21,7 @@ fn main() {
     let src_format_dir = src_dir.join("format");
     let src_codec_dir = src_dir.join("codec");
     let src_codec_audio_dir = src_codec_dir.join("audio");
+    let src_codec_subtitles_dir = src_codec_dir.join("subtitle");
     let src_codec_video_dir = src_codec_dir.join("video");
 
     println!("cargo:rerun-if-changed={}", src_dir.display());
@@ -50,6 +51,7 @@ fn main() {
         .file(src_codec_dir.join("mod.c"))
         .file(src_codec_dir.join("frame.c"))
         .file(src_codec_audio_dir.join("resampler.c"))
+        .file(src_codec_subtitles_dir.join("transcoder.c"))
         .file(src_codec_video_dir.join("scaler.c"))
         .compile("ffwrapper");
 

--- a/ac-ffmpeg/src/codec/mod.rs
+++ b/ac-ffmpeg/src/codec/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod audio;
 pub mod bsf;
+pub mod subtitle;
 pub mod video;
 
 use std::{
@@ -802,6 +803,11 @@ impl SubtitleCodecParameters {
 
         let res = SubtitleCodecParameters { inner: params };
         Ok(res)
+    }
+
+    /// Get raw pointer to the underlying object.
+    pub(crate) fn as_ptr(&self) -> *const c_void {
+        self.inner.ptr
     }
 
     /// Get name of the decoder that is able to decode this codec or None

--- a/ac-ffmpeg/src/codec/subtitle/mod.rs
+++ b/ac-ffmpeg/src/codec/subtitle/mod.rs
@@ -1,0 +1,257 @@
+use std::{
+    ffi::CString,
+    os::raw::{c_char, c_int, c_void},
+    ptr,
+};
+
+use crate::{packet::Packet, time::TimeBase, Error};
+
+use super::SubtitleCodecParameters;
+
+extern "C" {
+    fn ffw_subtitle_transcoder_new(
+        in_codec: *const c_char,
+        out_codec: *const c_char,
+    ) -> *mut c_void;
+    fn ffw_subtitle_transcoder_from_codec_parameters(
+        in_params: *const c_void,
+        out_params: *const c_void,
+    ) -> *mut c_void;
+    fn ffw_subtitle_decoder_set_initial_option(
+        transcoder: *mut c_void,
+        key: *const c_char,
+        value: *const c_char,
+    ) -> c_int;
+    fn ffw_subtitle_encoder_set_initial_option(
+        transcoder: *mut c_void,
+        key: *const c_char,
+        value: *const c_char,
+    ) -> c_int;
+    fn ffw_subtitle_transcoder_open(
+        transcoder: *mut c_void,
+        in_tb_num: c_int,
+        in_tb_den: c_int,
+        out_tb_num: c_int,
+        out_tb_den: c_int,
+    ) -> c_int;
+    fn ffw_subtitle_transcoder_push_packet(transcoder: *mut c_void, packet: *mut c_void) -> c_int;
+    fn ffw_subtitle_transcoder_take_packet(
+        transcoder: *mut c_void,
+        packet: *mut *mut c_void,
+    ) -> c_int;
+    fn ffw_subtitle_transcoder_free(transcoder: *mut c_void);
+}
+
+/// A builder for subtitle transcoders.
+
+pub struct SubtitleTranscoderBuilder {
+    ptr: *mut c_void,
+
+    input_time_base: TimeBase,
+    output_time_base: TimeBase,
+}
+
+impl SubtitleTranscoderBuilder {
+    /// Create a new builder.
+    fn new(in_codec: &str, out_codec: &str) -> Result<Self, Error> {
+        let in_codec = CString::new(in_codec).expect("invalid codec name");
+        let out_codec = CString::new(out_codec).expect("invalid codec name");
+
+        let ptr =
+            unsafe { ffw_subtitle_transcoder_new(in_codec.as_ptr() as _, out_codec.as_ptr() as _) };
+
+        if ptr.is_null() {
+            return Err(Error::new("unable to create transcoder"));
+        }
+
+        Ok(SubtitleTranscoderBuilder {
+            ptr,
+            input_time_base: TimeBase::MICROSECONDS,
+            output_time_base: TimeBase::MICROSECONDS,
+        })
+    }
+
+    /// Create a new builder from given codec parameters.
+    fn from_codec_parameters(
+        in_params: &SubtitleCodecParameters,
+        out_params: &SubtitleCodecParameters,
+    ) -> Result<Self, Error> {
+        let ptr = unsafe {
+            ffw_subtitle_transcoder_from_codec_parameters(in_params.as_ptr(), out_params.as_ptr())
+        };
+
+        if ptr.is_null() {
+            return Err(Error::new("unable to create transcoder"));
+        }
+
+        Ok(SubtitleTranscoderBuilder {
+            ptr,
+            input_time_base: TimeBase::MICROSECONDS,
+            output_time_base: TimeBase::MICROSECONDS,
+        })
+    }
+
+    /// Set a decoder option.
+    pub fn set_decoder_option<V>(self, name: &str, value: V) -> Self
+    where
+        V: ToString,
+    {
+        let name = CString::new(name).expect("invalid option name");
+        let value = CString::new(value.to_string()).expect("invalid option value");
+
+        let ret = unsafe {
+            ffw_subtitle_decoder_set_initial_option(
+                self.ptr,
+                name.as_ptr() as _,
+                value.as_ptr() as _,
+            )
+        };
+
+        if ret < 0 {
+            panic!("unable to allocate an option");
+        }
+
+        self
+    }
+
+    /// Set an encoder option.
+    pub fn set_encoder_option<V>(self, name: &str, value: V) -> Self
+    where
+        V: ToString,
+    {
+        let name = CString::new(name).expect("invalid option name");
+        let value = CString::new(value.to_string()).expect("invalid option value");
+
+        let ret = unsafe {
+            ffw_subtitle_encoder_set_initial_option(
+                self.ptr,
+                name.as_ptr() as _,
+                value.as_ptr() as _,
+            )
+        };
+
+        if ret < 0 {
+            panic!("unable to allocate an option");
+        }
+
+        self
+    }
+
+    /// Set input time base. By default it's in microseconds.
+    pub fn input_time_base(mut self, time_base: TimeBase) -> Self {
+        self.output_time_base = time_base;
+        self
+    }
+
+    /// Set output time base. By default it's in microseconds. All output
+    /// packets will use this time base.
+    pub fn output_time_base(mut self, time_base: TimeBase) -> Self {
+        self.output_time_base = time_base;
+        self
+    }
+
+    /// Build the transcoder.
+    pub fn build(mut self) -> Result<SubtitleTranscoder, Error> {
+        unsafe {
+            let ret = ffw_subtitle_transcoder_open(
+                self.ptr,
+                self.input_time_base.num() as _,
+                self.input_time_base.den() as _,
+                self.output_time_base.num() as _,
+                self.output_time_base.den() as _,
+            );
+            if ret != 0 {
+                return Err(Error::from_raw_error_code(ret));
+            }
+        }
+
+        let ptr = self.ptr;
+
+        self.ptr = ptr::null_mut();
+
+        let res = SubtitleTranscoder {
+            ptr,
+            output_time_base: self.output_time_base,
+        };
+
+        Ok(res)
+    }
+}
+
+impl Drop for SubtitleTranscoderBuilder {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe { ffw_subtitle_transcoder_free(self.ptr) }
+        }
+    }
+}
+
+unsafe impl Send for SubtitleTranscoderBuilder {}
+unsafe impl Sync for SubtitleTranscoderBuilder {}
+
+pub struct SubtitleTranscoder {
+    ptr: *mut c_void,
+
+    output_time_base: TimeBase,
+}
+
+impl SubtitleTranscoder {
+    /// Create a new video decoder for a given codec.
+    pub fn new(in_codec: &str, out_codec: &str) -> Result<Self, Error> {
+        SubtitleTranscoderBuilder::new(in_codec, out_codec).and_then(|builder| builder.build())
+    }
+
+    /// Create a new video decoder builder from given codec parameters.
+    pub fn from_codec_parameters(
+        in_params: &SubtitleCodecParameters,
+        out_params: &SubtitleCodecParameters,
+    ) -> Result<SubtitleTranscoderBuilder, Error> {
+        SubtitleTranscoderBuilder::from_codec_parameters(in_params, out_params)
+    }
+
+    /// Get decoder builder for a given codec.
+    pub fn builder(in_codec: &str, out_codec: &str) -> Result<SubtitleTranscoderBuilder, Error> {
+        SubtitleTranscoderBuilder::new(in_codec, out_codec)
+    }
+
+    /// Push a given packet to the transcoder.
+    pub fn push(&mut self, mut packet: Packet) -> Result<(), Error> {
+        unsafe {
+            let ret = ffw_subtitle_transcoder_push_packet(self.ptr, packet.as_mut_ptr());
+
+            if !(ret == crate::ffw_error_again()) && ret < 0 {
+                return Err(Error::from_raw_error_code(ret));
+            }
+        }
+
+        return Ok(());
+    }
+
+    /// Take the next packet from the transcoder.
+    pub fn take(&mut self) -> Result<Option<Packet>, Error> {
+        let mut pptr = ptr::null_mut();
+
+        unsafe {
+            let ret = ffw_subtitle_transcoder_take_packet(self.ptr, &mut pptr);
+
+            if ret == crate::ffw_error_again() || ret == crate::ffw_error_eof() {
+                Ok(None)
+            } else if ret < 0 {
+                Err(Error::from_raw_error_code(ret))
+            } else if pptr.is_null() {
+                panic!("unable to allocate a packet");
+            } else {
+                Ok(Some(Packet::from_raw_ptr(pptr, self.output_time_base)))
+            }
+        }
+    }
+}
+
+// impl Drop for SubtitleTranscoder {
+//     fn drop(&mut self) {
+//         unsafe { ffw_subtitle_transcoder_free(self.ptr) }
+//     }
+// }
+
+unsafe impl Send for SubtitleTranscoder {}
+unsafe impl Sync for SubtitleTranscoder {}

--- a/ac-ffmpeg/src/codec/subtitle/transcoder.c
+++ b/ac-ffmpeg/src/codec/subtitle/transcoder.c
@@ -1,0 +1,208 @@
+#include <libavcodec/avcodec.h>
+
+typedef struct SubtitleTranscoder {
+    const struct AVCodec* decoder;
+    struct AVCodecContext* decoder_ctx;
+    struct AVDictionary* decoder_options;
+    const struct AVCodec* encoder;
+    struct AVCodecContext* encoder_ctx;
+    struct AVDictionary* encoder_options;
+    struct AVSubtitle* subtitle;
+} SubtitleTranscoder;
+
+SubtitleTranscoder* ffw_subtitle_transcoder_new(const char* in_codec, const char* out_codec);
+SubtitleTranscoder* ffw_subtitle_transcoder_from_codec_parameters(const AVCodecParameters* in_params, const AVCodecParameters* out_params);
+int ffw_subtitle_decoder_set_initial_option(SubtitleTranscoder* transcoder, const char* key, const char* value);
+int ffw_subtitle_encoder_set_initial_option(SubtitleTranscoder* transcoder, const char* key, const char* value);
+int ffw_subtitle_transcoder_open(SubtitleTranscoder* transcoder, int in_tb_num, int in_tb_den, int out_tb_num, int out_tb_den);
+int ffw_subtitle_transcoder_push_packet(SubtitleTranscoder* transcoder, AVPacket* packet);
+int ffw_subtitle_transcoder_take_packet(SubtitleTranscoder* transcoder, AVPacket** packet);
+void ffw_subtitle_transcoder_free(SubtitleTranscoder* transcoder);
+
+SubtitleTranscoder* ffw_subtitle_transcoder_new(const char* in_codec, const char* out_codec) {
+    const AVCodec* decoder = avcodec_find_decoder_by_name(in_codec);
+    if (decoder == NULL) {
+        return NULL;
+    }
+
+    const AVCodec* encoder = avcodec_find_encoder_by_name(out_codec);
+    if (encoder == NULL) {
+        return NULL;
+    }
+
+    SubtitleTranscoder* res = malloc(sizeof(SubtitleTranscoder));
+    if (res == NULL) {
+        return NULL;
+    }
+
+    res->decoder = decoder;
+    res->decoder_ctx = avcodec_alloc_context3(decoder);
+    if (res->decoder_ctx == NULL) {
+        goto err;
+    }
+    res->decoder_options = NULL;
+
+    res->encoder = encoder;
+    res->encoder_ctx = avcodec_alloc_context3(encoder);
+    if (res->encoder == NULL) {
+        goto err;
+    }
+    res->encoder_options = NULL;
+
+    res->subtitle = malloc(sizeof(AVSubtitle));
+    return res;
+
+err:
+    ffw_subtitle_transcoder_free(res);
+
+    return NULL;
+}
+
+SubtitleTranscoder* ffw_subtitle_transcoder_from_codec_parameters(const AVCodecParameters* in_params, const AVCodecParameters* out_params) {
+
+    const AVCodec* decoder = avcodec_find_decoder(in_params->codec_id);
+    if (decoder == NULL) {
+        return NULL;
+    }
+
+    const AVCodec* encoder = avcodec_find_encoder(out_params->codec_id);
+    if (encoder == NULL) {
+        return NULL;
+    }
+
+    SubtitleTranscoder* res = malloc(sizeof(SubtitleTranscoder));
+    if (res == NULL) {
+        return NULL;
+    }
+
+    res->decoder = decoder;
+    res->decoder_ctx = avcodec_alloc_context3(decoder);
+    if (res->decoder_ctx == NULL) {
+        goto err;
+    }
+    if (avcodec_parameters_to_context(res->decoder_ctx, in_params) < 0) {
+        goto err;
+    }
+    res->decoder_options = NULL;
+
+    res->encoder = encoder;
+    res->encoder_ctx = avcodec_alloc_context3(encoder);
+    if (res->encoder == NULL) {
+        goto err;
+    }
+    if (avcodec_parameters_to_context(res->encoder_ctx, out_params) < 0) {
+        goto err;
+    }
+    res->encoder_options = NULL;
+
+    res->subtitle = malloc(sizeof(AVSubtitle));
+    return res;
+
+err:
+    ffw_subtitle_transcoder_free(res);
+
+    return NULL;
+}
+
+int ffw_subtitle_decoder_set_initial_option(SubtitleTranscoder* transcoder, const char* key, const char* value) {
+    return av_dict_set(&transcoder->decoder_options, key, value, 0);
+}
+
+int ffw_subtitle_encoder_set_initial_option(SubtitleTranscoder* transcoder, const char* key, const char* value) {
+    return av_dict_set(&transcoder->encoder_options, key, value, 0);
+}
+
+int ffw_subtitle_transcoder_open(SubtitleTranscoder* transcoder, int in_tb_num, int in_tb_den, int out_tb_num, int out_tb_den) {
+    // open decoder
+    AVRational in_tb;
+    in_tb.num = in_tb_num;
+    in_tb.den = in_tb_den;
+    transcoder->decoder_ctx->time_base = in_tb;
+    transcoder->decoder_ctx->pkt_timebase = in_tb;
+    int ret = avcodec_open2(transcoder->decoder_ctx, transcoder->decoder, &transcoder->decoder_options);
+    if (ret != 0) {
+        return ret;
+    }
+
+    // pass through e.g style headers from decoder
+    transcoder->encoder_ctx->subtitle_header = transcoder->decoder_ctx->subtitle_header;
+    transcoder->encoder_ctx->subtitle_header_size = transcoder->decoder_ctx->subtitle_header_size;
+
+    // open encoder
+    AVRational out_tb;
+    out_tb.num = out_tb_num;
+    out_tb.den = out_tb_den;
+    transcoder->encoder_ctx->time_base = out_tb;
+    transcoder->encoder_ctx->pkt_timebase = out_tb;
+    ret = avcodec_open2(transcoder->encoder_ctx, transcoder->encoder, &transcoder->encoder_options);
+    return ret;
+}
+
+int ffw_subtitle_transcoder_push_packet(SubtitleTranscoder* transcoder, AVPacket* packet) {
+    int got_output;
+    int ret = avcodec_decode_subtitle2(transcoder->decoder_ctx, transcoder->subtitle, &got_output, packet);
+    if (ret < 0) {
+        av_log(NULL, AV_LOG_ERROR, "failed to decode subtitle packet\n");
+        return ret;
+    }
+    if (got_output == 0) {
+        return AVERROR(EAGAIN);
+    }
+    return 0;
+}
+
+int ffw_subtitle_transcoder_take_packet(SubtitleTranscoder* transcoder, AVPacket** packet) {
+    if (transcoder->subtitle->num_rects == 0) {
+        return AVERROR(EAGAIN);
+    }
+
+    int subtitle_out_max_size = 1024 * 1024; // these are the values ffmpeg uses
+    int subtitle_out_size;
+    static uint8_t* subtitle_out;
+    subtitle_out = av_malloc(subtitle_out_max_size);
+    if (!subtitle_out) {
+        av_log(NULL, AV_LOG_FATAL, "Failed to allocate subtitle out\n");
+        return 1;
+    }
+
+    subtitle_out_size = avcodec_encode_subtitle(transcoder->encoder_ctx, subtitle_out, subtitle_out_max_size, transcoder->subtitle);
+    if (subtitle_out_size < 0) {
+        av_log(NULL, AV_LOG_FATAL, "Subtitle encoding failed\n");
+        return 1;
+    }
+
+    AVPacket* out = av_packet_alloc();
+    out->data = subtitle_out;
+    out->size = subtitle_out_size;
+    out->pts = transcoder->subtitle->pts;
+    out->duration = transcoder->subtitle->end_display_time;
+    *packet = out;
+
+    avsubtitle_free(transcoder->subtitle);
+    return 0;
+}
+
+void ffw_subtitle_transcoder_free(SubtitleTranscoder* transcoder)
+{
+    if (transcoder == NULL) {
+        return;
+    }
+
+    if (transcoder->subtitle != NULL) {
+        avsubtitle_free(transcoder->subtitle);
+    }
+
+    if (transcoder->decoder_ctx != NULL) {
+        avcodec_free_context(&transcoder->decoder_ctx);
+    }
+    if (transcoder->decoder_options != NULL) {
+        avcodec_free_context(&transcoder->decoder_ctx);
+    }
+    if (transcoder->encoder_ctx != NULL) {
+        avcodec_free_context(&transcoder->encoder_ctx);
+    }
+    if (transcoder->encoder_options != NULL) {
+        avcodec_free_context(&transcoder->decoder_ctx);
+    }
+    free(transcoder);
+}


### PR DESCRIPTION
Based loosely on the ffmpeg implementation using avcodec_decode_subtitle2 and avcodec_encode_subtitle, adds a transcoder for converting subtitle formats.

Thanks in advance for your time considering this PR and providing any feedback.

NB: if sub_charenc is required it should be set on the demuxer
