### PR TITLE
Expose codec flags

### DIFF
--- a/ac-ffmpeg/src/codec/audio/mod.rs
+++ b/ac-ffmpeg/src/codec/audio/mod.rs
@@ -7,7 +7,10 @@ pub mod transcoder;
 use std::{ffi::CString, os::raw::c_void, ptr};
 
 use crate::{
-    codec::{AudioCodecParameters, CodecError, CodecParameters, CodecTag, Decoder, Encoder},
+    codec::{
+        AudioCodecParameters, CodecError, CodecFlag, CodecFlag2, CodecParameters, CodecTag,
+        Decoder, Encoder,
+    },
     format::stream::Stream,
     packet::Packet,
     time::TimeBase,
@@ -417,6 +420,24 @@ impl AudioEncoderBuilder {
     pub fn codec_tag(self, codec_tag: impl Into<CodecTag>) -> Self {
         unsafe {
             super::ffw_encoder_set_codec_tag(self.raw.ptr, codec_tag.into().into());
+        }
+
+        self
+    }
+
+    /// Set a codec flag.
+    pub fn set_flag(self, flag: CodecFlag) -> Self {
+        unsafe {
+            super::ffw_encoder_set_flag(self.raw.ptr, flag.into_raw());
+        }
+
+        self
+    }
+
+    /// Set a codec flag using the second set of flags.
+    pub fn set_flag2(self, flag2: CodecFlag2) -> Self {
+        unsafe {
+            super::ffw_encoder_set_flag2(self.raw.ptr, flag2.into_raw());
         }
 
         self

--- a/ac-ffmpeg/src/codec/mod.c
+++ b/ac-ffmpeg/src/codec/mod.c
@@ -427,6 +427,8 @@ void ffw_encoder_set_sample_format(Encoder* encoder, int format);
 void ffw_encoder_set_sample_rate(Encoder* encoder, int sample_rate);
 void ffw_encoder_set_codec_tag(Encoder* encoder, uint32_t codec_tag);
 int ffw_encoder_set_initial_option(Encoder* encoder, const char* key, const char* value);
+void ffw_encoder_set_flag(Encoder* encoder, int flag);
+void ffw_encoder_set_flag2(Encoder* encoder, int flag2);
 int ffw_encoder_open(Encoder* encoder);
 int ffw_encoder_push_frame(Encoder* encoder, const AVFrame* frame);
 int ffw_encoder_take_packet(Encoder* encoder, AVPacket** packet);
@@ -619,6 +621,14 @@ void ffw_encoder_set_codec_tag(Encoder* encoder, uint32_t codec_tag) {
 
 int ffw_encoder_set_initial_option(Encoder* encoder, const char* key, const char* value) {
     return av_dict_set(&encoder->options, key, value, 0);
+}
+
+void ffw_encoder_set_flag(Encoder* encoder, int flag) {
+    encoder->cc->flags |= flag;
+}
+
+void ffw_encoder_set_flag2(Encoder* encoder, int flag2) {
+    encoder->cc->flags2 |= flag2;
 }
 
 int ffw_encoder_open(Encoder* encoder) {

--- a/ac-ffmpeg/src/codec/mod.rs
+++ b/ac-ffmpeg/src/codec/mod.rs
@@ -93,6 +93,8 @@ extern "C" {
         key: *const c_char,
         value: *const c_char,
     ) -> c_int;
+    fn ffw_encoder_set_flag(encoder: *mut c_void, flag: c_int);
+    fn ffw_encoder_set_flag2(encoder: *mut c_void, flag2: c_int);
     fn ffw_encoder_open(encoder: *mut c_void) -> c_int;
     fn ffw_encoder_push_frame(encoder: *mut c_void, frame: *const c_void) -> c_int;
     fn ffw_encoder_take_packet(encoder: *mut c_void, packet: *mut *mut c_void) -> c_int;
@@ -903,6 +905,94 @@ impl From<CodecTag> for u32 {
 impl From<&[u8; 4]> for CodecTag {
     fn from(value: &[u8; 4]) -> Self {
         Self(u32::from_le_bytes(*value))
+    }
+}
+
+/// Codec flags used to control encoder behavior when passed to AVCodecContext
+pub enum CodecFlag {
+    Unaligned,
+    QScale,
+    FourMV,
+    OutputCorrupt,
+    QPEL,
+    DropChanged,
+    ReconFrame,
+    CopyOpaque,
+    FrameDuration,
+    Pass1,
+    Pass2,
+    LoopFilter,
+    Gray,
+    PSNR,
+    Truncated,
+    InterlacedDCT,
+    LowDelay,
+    GlobalHeader,
+    BitExact,
+    ACPred,
+    InterlacedME,
+    ClosedGOP,
+}
+
+impl CodecFlag {
+    fn into_raw(self) -> i32 {
+        match self {
+            CodecFlag::Unaligned => 1 << 0,
+            CodecFlag::QScale => 1 << 1,
+            CodecFlag::FourMV => 1 << 2,
+            CodecFlag::OutputCorrupt => 1 << 3,
+            CodecFlag::QPEL => 1 << 4,
+            CodecFlag::DropChanged => 1 << 5,
+            CodecFlag::ReconFrame => 1 << 6,
+            CodecFlag::CopyOpaque => 1 << 7,
+            CodecFlag::FrameDuration => 1 << 8,
+            CodecFlag::Pass1 => 1 << 9,
+            CodecFlag::Pass2 => 1 << 10,
+            CodecFlag::LoopFilter => 1 << 11,
+            CodecFlag::Gray => 1 << 13,
+            CodecFlag::PSNR => 1 << 15,
+            CodecFlag::Truncated => 1 << 16,
+            CodecFlag::InterlacedDCT => 1 << 18,
+            CodecFlag::LowDelay => 1 << 19,
+            CodecFlag::GlobalHeader => 1 << 22,
+            CodecFlag::BitExact => 1 << 23,
+            CodecFlag::ACPred => 1 << 24,
+            CodecFlag::InterlacedME => 1 << 29,
+            CodecFlag::ClosedGOP => 1 << 31,
+        }
+    }
+}
+
+/// More codec flags used to control encoder behavior when passed to AVCodecContext
+pub enum CodecFlag2 {
+    Fast,
+    NoOutput,
+    LocalHeader,
+    DropFrameTimecode,
+    Chunks,
+    IgnoreCrop,
+    ShowAll,
+    ExportMVS,
+    SkipManual,
+    ROFlushNoOp,
+    ICCProfiles
+}
+
+impl CodecFlag2 {
+    fn into_raw(self) -> i32 {
+        match self {
+            CodecFlag2::Fast => 1 << 0,
+            CodecFlag2::NoOutput => 1 << 2,
+            CodecFlag2::LocalHeader => 1 << 3,
+            CodecFlag2::DropFrameTimecode => 1 << 13,
+            CodecFlag2::Chunks => 1 << 15,
+            CodecFlag2::IgnoreCrop => 1 << 16,
+            CodecFlag2::ShowAll => 1 << 22,
+            CodecFlag2::ExportMVS => 1 << 28,
+            CodecFlag2::SkipManual => 1 << 29,
+            CodecFlag2::ROFlushNoOp => 1 << 30,
+            CodecFlag2::ICCProfiles => 1 << 31,
+        }
     }
 }
 

--- a/ac-ffmpeg/src/codec/video/mod.rs
+++ b/ac-ffmpeg/src/codec/video/mod.rs
@@ -6,7 +6,10 @@ pub mod scaler;
 use std::{ffi::CString, os::raw::c_void, ptr};
 
 use crate::{
-    codec::{CodecError, CodecParameters, CodecTag, Decoder, Encoder, VideoCodecParameters},
+    codec::{
+        CodecError, CodecFlag, CodecFlag2, CodecParameters, CodecTag, Decoder, Encoder,
+        VideoCodecParameters,
+    },
     format::stream::Stream,
     packet::Packet,
     time::TimeBase,
@@ -387,6 +390,24 @@ impl VideoEncoderBuilder {
     pub fn codec_tag(self, codec_tag: impl Into<CodecTag>) -> Self {
         unsafe {
             super::ffw_encoder_set_codec_tag(self.ptr, codec_tag.into().into());
+        }
+
+        self
+    }
+
+    /// Set a codec flag.
+    pub fn set_flag(self, flag: CodecFlag) -> Self {
+        unsafe {
+            super::ffw_encoder_set_flag(self.ptr, flag.into_raw());
+        }
+
+        self
+    }
+
+    /// Set a codec flag using the second set of flags.
+    pub fn set_flag2(self, flag2: CodecFlag2) -> Self {
+        unsafe {
+            super::ffw_encoder_set_flag2(self.ptr, flag2.into_raw());
         }
 
         self


### PR DESCRIPTION
I needed to set AV_CODEC_FLAG_GLOBAL_HEADER to get the correct encoder extradata for an RTMP application, here are the changes I made to achieve that.

A few notes:

1.  The set of flags defined in avcodec.h differs between ffmpeg 4.x and 5.x, here I have included flags from both versions
2.  The flags are split into two sets, same as in libavcodec, but they could also be merged into one set in the Rust interface
3.  The names of the flags are not very descriptive, and their function could change in future libavcodec versions. It might make sense to include a way to pass in an arbitrary flag value in addition to the predefined ones, just to cover all use cases.