### PR TITLE
fix seeking - need to handle `whence` properly

### DIFF
--- a/ac-ffmpeg/src/format/io.c
+++ b/ac-ffmpeg/src/format/io.c
@@ -5,8 +5,17 @@ typedef int read_packet_t(void*, uint8_t*, int);
 typedef int write_packet_t(void*, uint8_t*, int);
 typedef int64_t seek_t(void*, int64_t, int);
 
-int ffw_io_is_avseek_size(int whence) {
-    return whence & AVSEEK_SIZE;
+int ffw_io_whence_to_seek_mode(int whence) {
+    if (whence & AVSEEK_SIZE) {
+        return 0;
+    }
+
+    switch (whence) {
+        case SEEK_SET: return 1;
+        case SEEK_CUR: return 2;
+        case SEEK_END: return 3;
+        default: return -1;
+    }
 }
 
 AVIOContext * ffw_io_context_new(


### PR DESCRIPTION
per docs, the whence parameter is set as in [fseek](https://man7.org/linux/man-pages/man3/fseek.3.html)

for example, it's not uncommon for this callback to be called with `whence = 2, offset = -1` indicating seek 1 byte from the end of the stream

before this change, we'd cast this -1 to u64 which is `18446744073709551615` - and then we'd try to seek to that position!

my change correctly handles whence + also adds extra safety in the i64 -> u64 cast in the SEEK_SET case