### PR TITLE
Add `duration` and `bit_rate` from container

### DIFF
--- a/ac-ffmpeg/src/format/demuxer.c
+++ b/ac-ffmpeg/src/format/demuxer.c
@@ -59,6 +59,8 @@ int ffw_demuxer_init(Demuxer* demuxer, AVIOContext* io_context, AVInputFormat* f
 int ffw_demuxer_set_initial_option(Demuxer* demuxer, const char* key, const char* value);
 int ffw_demuxer_set_option(Demuxer* demuxer, const char* key, const char* value);
 int ffw_demuxer_find_stream_info(Demuxer* demuxer, int64_t max_analyze_duration);
+int ffw_demuxer_get_bit_rate(Demuxer* demuxer);
+int ffw_demuxer_get_duration(Demuxer* demuxer);
 unsigned ffw_demuxer_get_nb_streams(const Demuxer* demuxer);
 AVStream* ffw_demuxer_get_stream(Demuxer* demuxer, unsigned stream_index);
 const AVInputFormat* ffw_demuxer_get_input_format(const Demuxer* demuxer);
@@ -128,6 +130,14 @@ int ffw_demuxer_find_stream_info(Demuxer* demuxer, int64_t max_analyze_duration)
     demuxer->fc->max_analyze_duration = max_analyze_duration;
 
     return avformat_find_stream_info(demuxer->fc, NULL);
+}
+
+int ffw_demuxer_get_bit_rate(Demuxer* demuxer) {
+    return demuxer->fc->bit_rate;
+}
+
+int ffw_demuxer_get_duration(Demuxer* demuxer) {
+    return demuxer->fc->duration;
 }
 
 unsigned ffw_demuxer_get_nb_streams(const Demuxer* demuxer) {

--- a/ac-ffmpeg/src/format/demuxer.rs
+++ b/ac-ffmpeg/src/format/demuxer.rs
@@ -45,6 +45,8 @@ extern "C" {
     fn ffw_demuxer_get_nb_streams(demuxer: *const c_void) -> c_uint;
     fn ffw_demuxer_get_stream(demuxer: *mut c_void, index: c_uint) -> *mut c_void;
     fn ffw_demuxer_get_input_format(demuxer: *const c_void) -> *const c_void;
+    fn ffw_demuxer_get_bit_rate(demuxer: *const c_void) -> c_int;
+    fn ffw_demuxer_get_duration(demuxer: *const c_void) -> c_int;
     fn ffw_demuxer_read_frame(
         demuxer: *mut c_void,
         packet: *mut *mut c_void,
@@ -332,6 +334,18 @@ impl<T> Demuxer<T> {
         };
 
         Ok(res)
+    }
+
+    pub fn get_bit_rate(&self) -> Result<i32, Error> {
+        let ret = unsafe { ffw_demuxer_get_bit_rate(self.ptr) };
+
+        Ok(ret)
+    }
+
+    pub fn get_duration(&self) -> Result<i32, Error> {
+        let ret = unsafe { ffw_demuxer_get_duration(self.ptr) };
+
+        Ok(ret)
     }
 
     pub fn input_format(&self) -> InputFormat {


### PR DESCRIPTION
For some video format, like MKV, the duration and bit rate information is not at the stream level but at the container level. 
Adding two new functions to get the values at that level

(would close https://github.com/angelcam/rust-ac-ffmpeg/issues/84)