### PR TITLE
Expose frame rate of streams

### DIFF
--- a/ac-ffmpeg/src/format/stream.c
+++ b/ac-ffmpeg/src/format/stream.c
@@ -10,6 +10,16 @@ void ffw_stream_set_time_base(AVStream* stream, int num, int den) {
     stream->time_base.den = den;
 }
 
+void ffw_stream_get_r_frame_rate(const AVStream* stream, int* num, int* den) {
+    *num = stream->r_frame_rate.num;
+    *den = stream->r_frame_rate.den;
+}
+
+void ffw_stream_get_avg_frame_rate(const AVStream* stream, int* num, int* den) {
+    *num = stream->avg_frame_rate.num;
+    *den = stream->avg_frame_rate.den;
+}
+
 int64_t ffw_stream_get_start_time(const AVStream* stream) {
     return stream->start_time;
 }

--- a/ac-ffmpeg/src/format/stream.rs
+++ b/ac-ffmpeg/src/format/stream.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::{
     codec::CodecParameters,
+    math::Rational,
     time::{TimeBase, Timestamp},
 };
 
@@ -19,6 +20,8 @@ use crate::{
 extern "C" {
     fn ffw_stream_get_time_base(stream: *const c_void, num: *mut c_int, den: *mut c_int);
     fn ffw_stream_set_time_base(stream: *mut c_void, num: c_int, den: c_int);
+    fn ffw_stream_get_r_frame_rate(stream: *const c_void, num: *mut c_int, den: *mut c_int);
+    fn ffw_stream_get_avg_frame_rate(stream: *const c_void, num: *mut c_int, den: *mut c_int);
     fn ffw_stream_get_start_time(stream: *const c_void) -> i64;
     fn ffw_stream_get_duration(stream: *const c_void) -> i64;
     fn ffw_stream_get_nb_frames(stream: *const c_void) -> i64;
@@ -82,6 +85,34 @@ impl Stream {
                 self.time_base.num() as _,
                 self.time_base.den() as _,
             );
+        }
+    }
+
+    /// Get real base framerate of the stream.
+    pub fn r_frame_rate(&self) -> Rational {
+        let mut num = 0;
+        let mut den = 0;
+
+        unsafe {
+            ffw_stream_get_r_frame_rate(self.ptr, &mut num, &mut den);
+        }
+
+        Rational::new(num, den)
+    }
+
+    /// Get average stream frame rate.
+    pub fn avg_frame_rate(&self) -> Option<Rational> {
+        let mut num = 0;
+        let mut den = 0;
+
+        unsafe {
+            ffw_stream_get_avg_frame_rate(self.ptr, &mut num, &mut den);
+        }
+
+        if num != 0 && den != 0 {
+            Some(Rational::new(num, den))
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
Updated version of #35

~~Changes `TimeBase` to use a shared type `Rational`, together with the frame rate. As a consequence, TimeBase now uses `int` instead of `uint32` internally, which matches the types ffmpeg itself uses: <https://ffmpeg.org/doxygen/trunk/structAVRational.html>~~